### PR TITLE
add version support to all arch examples

### DIFF
--- a/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/README.md
+++ b/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/README.md
@@ -4,6 +4,16 @@
 
 1 Shard with replication across clickhouse-01 and clickhouse-02
 
+By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
+will be `latest-alpine`.  You can specify specific versions by setting environment
+variables before running `docker compose up`.
+
+```bash
+export CHVER=23.4
+export CHKVER=23.4-alpine
+docker compose up
+```
+
 This Docker compose file deploys a configuration very similar to [this
 example in the documentation](https://clickhouse.com/docs/en/architecture/replication), the main difference is that this adds Chproxy.
 See the docs for information on terminology, configuration, and testing.

--- a/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '1.0'
 services:
   clickhouse-01:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-01
     hostname: clickhouse-01
@@ -19,7 +19,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-02:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-02
     hostname: clickhouse-02
@@ -37,7 +37,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-keeper-01:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
@@ -49,7 +49,7 @@ services:
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-02
     hostname: clickhouse-keeper-02
@@ -61,7 +61,7 @@ services:
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-03
     hostname: clickhouse-keeper-03

--- a/docker-compose-recipes/recipes/cluster_2S_1R/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_1R/README.md
@@ -4,6 +4,16 @@
 
 2 Shards with no replication configured
 
+By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
+will be `latest-alpine`.  You can specify specific versions by setting environment
+variables before running `docker compose up`.
+
+```bash
+export CHVER=23.4
+export CHKVER=23.4-alpine
+docker compose up
+```
+
 This Docker compose file deploys a configuration similar to [this
 example in the documentation](https://clickhouse.com/docs/en/architecture/horizontal-scaling) with the main difference being that 3 independent ClickHouse keeper instances are used in this recipe (instead of just one as in the docs).
 See the docs for information on terminology, configuration, and testing.

--- a/docker-compose-recipes/recipes/cluster_2S_1R/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_2S_1R/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '1.0'
 services:
   clickhouse-01:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-01
     hostname: clickhouse-01
@@ -19,7 +19,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-02:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-02
     hostname: clickhouse-02
@@ -37,7 +37,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-keeper-01:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
@@ -49,7 +49,7 @@ services:
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-02
     hostname: clickhouse-keeper-02
@@ -61,7 +61,7 @@ services:
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-03
     hostname: clickhouse-keeper-03

--- a/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/README.md
@@ -4,6 +4,15 @@
 
 2 Shards with no replication configured
 
+By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
+will be `latest-alpine`.  You can specify specific versions by setting environment
+variables before running `docker compose up`.
+
+```bash
+export CHVER=23.4
+export CHKVER=23.4-alpine
+docker compose up
+```
 
 This Docker compose file deploys a configuration similar to [this
 example in the documentation](https://clickhouse.com/docs/en/architecture/horizontal-scaling) with the main difference being that 3 independent ClickHouse keeper instances are used in this recipe (instead of just one as in the docs).

--- a/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '1.0'
 services:
   clickhouse-01:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-01
     hostname: clickhouse-01
@@ -19,7 +19,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-02:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-02
     hostname: clickhouse-02
@@ -37,7 +37,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-keeper-01:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
@@ -49,7 +49,7 @@ services:
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-02
     hostname: clickhouse-keeper-02
@@ -61,7 +61,7 @@ services:
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-03
     hostname: clickhouse-keeper-03

--- a/docker-compose-recipes/recipes/cluster_2S_2R/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_2R/README.md
@@ -6,6 +6,16 @@
 - across clickhouse-01 and clickhouse-03 for shard 01
 - across clickhouse-02 and clickhouse-04 for shard 02
 
+By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
+will be `latest-alpine`.  You can specify specific versions by setting environment
+variables before running `docker compose up`.
+
+```bash
+export CHVER=23.4
+export CHKVER=23.4-alpine
+docker compose up
+```
+
 This Docker compose file deploys a configuration very similar to [these two
 examples in the documentation](https://clickhouse.com/docs/en/architecture/introduction).
 See the docs for information on terminology, configuration, and testing.

--- a/docker-compose-recipes/recipes/cluster_2S_2R/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '1.0'
 services:
   clickhouse-01:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-01
     hostname: clickhouse-01
@@ -16,7 +16,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-02:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-02
     hostname: clickhouse-02
@@ -31,7 +31,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-03:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-03
     hostname: clickhouse-03
@@ -46,7 +46,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-04:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-04
     hostname: clickhouse-04
@@ -61,7 +61,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-keeper-01:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
@@ -70,7 +70,7 @@ services:
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-02
     hostname: clickhouse-keeper-02
@@ -79,7 +79,7 @@ services:
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-03
     hostname: clickhouse-keeper-03

--- a/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/README.md
@@ -6,6 +6,16 @@
 - across clickhouse-01 and clickhouse-03 for shard 01
 - across clickhouse-02 and clickhouse-04 for shard 02
 
+By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
+will be `latest-alpine`.  You can specify specific versions by setting environment
+variables before running `docker compose up`.
+
+```bash
+export CHVER=23.4
+export CHKVER=23.4-alpine
+docker compose up
+```
+
 This Docker compose file deploys a configuration very similar to [these
 examples in the documentation](https://clickhouse.com/docs/en/architecture/introduction).
 See the docs for information on terminology, configuration, and testing.

--- a/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '1.0'
 services:
   clickhouse-01:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-01
     hostname: clickhouse-01
@@ -19,7 +19,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-02:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-02
     hostname: clickhouse-02
@@ -37,7 +37,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-03:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-03
     hostname: clickhouse-03
@@ -55,7 +55,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-04:
-    image: clickhouse/clickhouse-server
+    image: "clickhouse/clickhouse-server:${CHVER:-latest}"
     user: "101:101"
     container_name: clickhouse-04
     hostname: clickhouse-04
@@ -73,7 +73,7 @@ services:
       - clickhouse-keeper-02
       - clickhouse-keeper-03
   clickhouse-keeper-01:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
@@ -85,7 +85,7 @@ services:
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-02
     hostname: clickhouse-keeper-02
@@ -97,7 +97,7 @@ services:
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
-    image: clickhouse/clickhouse-keeper
+    image: "clickhouse/clickhouse-keeper:${CHKVER:-latest-alpine}"
     user: "101:101"
     container_name: clickhouse-keeper-03
     hostname: clickhouse-keeper-03


### PR DESCRIPTION
I made the same changes to all of the cluster examples and then checked with:
```bash
export CHKVER=23.4-alpine
export CHVER=22.2
```

and in each dir
```
docker compose config|grep image
```
