### PR TITLE
[docker-examples] use default user and no password

### DIFF
--- a/docker-compose-recipes/README.md
+++ b/docker-compose-recipes/README.md
@@ -43,11 +43,13 @@ to learn how ClickHouse Keeper is configured for the `cluster_1S_2R` recipe, you
 
 ## Connecting to ClickHouse
 
-If you have `clickhouse client` on your workstation you can generally run `clickhouse client --user admin --password password` and connect to the Docker ClickHouse instance.
+All recipes have the `default` user configured with no password and full privileges.
+
+If you have `clickhouse client` on your workstation you can generally run `clickhouse client` and connect to the Docker ClickHouse instance.
 
 If running a recipe with multiple ClickHouse ([example](https://github.com/ClickHouse/examples/tree/main/docker-compose-recipes/recipes/cluster_2S_1R)), while the first instance normally binds to your localhost as the default ClickHouse native protocol port [9000](https://github.com/ClickHouse/examples//blob/93291fe2ca143d7d0ec1ec02ad61f50dc2f83788/docker-compose-recipes/recipes/cluster_2S_2R/docker-compose.yaml#L13-L14) normally, however other instances will use a different port to bind the ClickHouse native TCP connection to your localhost ([example](https://github.com/ClickHouse/examples/blob/93291fe2ca143d7d0ec1ec02ad61f50dc2f83788/docker-compose-recipes/recipes/cluster_2S_2R/docker-compose.yaml#L28) where `clickhouse-02` binds on localhost port `9001`), in this case you will want to specify:
 
-`clickhouse client --user admin --password passwod --port 9001`
+`clickhouse client --port 9001`
 
 
 You may want to run `clickhouse client` within one of more of the containers so that the version of the client matches the version

--- a/docker-compose-recipes/recipes/ch-and-grafana/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/ch-and-grafana/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/ch-and-grafana/fs/volumes/grafana/etc/grafana/provisioning/datasources/clickhouse.yml
+++ b/docker-compose-recipes/recipes/ch-and-grafana/fs/volumes/grafana/etc/grafana/provisioning/datasources/clickhouse.yml
@@ -6,7 +6,5 @@ datasources:
       defaultDatabase: default
       port: 9000
       server: clickhouse
-      username: admin
+      username: default
       tlsSkipVerify: false
-    secureJsonData:
-      password: password

--- a/docker-compose-recipes/recipes/ch-and-minio-S3/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/ch-and-minio-S3/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/ch-and-openldap/README.md
+++ b/docker-compose-recipes/recipes/ch-and-openldap/README.md
@@ -130,7 +130,7 @@ the rest of configuration to define the LDAP server and map the LDAP groups to C
     </user_directories>
 ```
 
-All users are using password: `password`
+All LDAP users are using password: `password`
 
 You can validate the LDAP schema using PhpLDAPAdmin UI at http://localhost
 

--- a/docker-compose-recipes/recipes/ch-and-openldap/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/ch-and-openldap/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
@@ -21,19 +21,6 @@
             <show_named_collections>1</show_named_collections>
             <show_named_collections_secrets>1</show_named_collections_secrets>
         </default>
-        <admin>
-            <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-            <access_management>1</access_management>
-            <named_collection_control>1</named_collection_control>
-            <show_named_collections>1</show_named_collections>
-            <show_named_collections_secrets>1</show_named_collections_secrets>
-        </admin>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/ch-and-postgres/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/ch-and-postgres/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/ch-and-vector/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/ch-and-vector/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/ch-and-vector/fs/volumes/vector/vector.toml
+++ b/docker-compose-recipes/recipes/ch-and-vector/fs/volumes/vector/vector.toml
@@ -46,8 +46,8 @@ skip_unknown_fields = false
 
   [sinks.clickhouse-syslog-data.auth]
   strategy = "basic"
-  user = "admin"
-  password = "password"
+  user = "default"
+  password = ""
 
   [sinks.clickhouse-syslog-data.request]
   retry_attempts = 0
@@ -62,8 +62,8 @@ skip_unknown_fields = false
 
   [sinks.clickhouse-apache-data.auth]
   strategy = "basic"
-  user = "admin"
-  password = "password"
+  user = "default"
+  password = ""
 
   [sinks.clickhouse-apache-data.request]
   retry_attempts = 0

--- a/docker-compose-recipes/recipes/cluster_1S_2R/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_1S_2R/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_1S_2R/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_1S_2R/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/fs/volumes/ch-proxy/config/config.yml
+++ b/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/fs/volumes/ch-proxy/config/config.yml
@@ -1,20 +1,18 @@
 server:
   http:
-    listen_addr: ":80"
-    allowed_networks: ["127.0.0.0/24", "192.168.5.0/24"]
+    listen_addr: ':80'
+    allowed_networks: ['127.0.0.0/24', '192.168.5.0/24']
 users:
-  - name: "admin_1S_2R"
-    password: "password"
-    to_cluster: "cluster_1S_2R"
-    to_user: "admin"
+  - name: 'admin_1S_2R'
+    to_cluster: 'cluster_1S_2R'
+    to_user: 'default'
     max_concurrent_queries: 100
     max_execution_time: 30s
     requests_per_minute: 10
     # Allow `CORS` requests for `tabix`.
     allow_cors: true
 clusters:
-  - name: "cluster_1S_2R"
-    nodes: ["clickhouse-01:8123", "clickhouse-02:8123"]
+  - name: 'cluster_1S_2R'
+    nodes: ['clickhouse-01:8123', 'clickhouse-02:8123']
     users:
-      - name: "admin"
-        password: "password"
+      - name: 'default'

--- a/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_1R/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_1R/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_1R/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_1R/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/fs/volumes/ch-proxy/config/config.yml
+++ b/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/fs/volumes/ch-proxy/config/config.yml
@@ -1,20 +1,18 @@
 server:
   http:
-    listen_addr: ":80"
-    allowed_networks: ["127.0.0.0/24", "192.168.7.0/24"]
+    listen_addr: ':80'
+    allowed_networks: ['127.0.0.0/24', '192.168.7.0/24']
 users:
-  - name: "admin_2S_1R"
-    password: "password"
-    to_cluster: "cluster_2S_1R"
-    to_user: "admin"
+  - name: 'admin_2S_1R'
+    to_cluster: 'cluster_2S_1R'
+    to_user: 'default'
     max_concurrent_queries: 100
     max_execution_time: 30s
     requests_per_minute: 10
     # Allow `CORS` requests for `tabix`.
     allow_cors: true
 clusters:
-  - name: "cluster_2S_1R"
-    nodes: ["clickhouse-01:8123", "clickhouse-02:8123"]
+  - name: 'cluster_2S_1R'
+    nodes: ['clickhouse-01:8123', 'clickhouse-02:8123']
     users:
-      - name: "admin"
-        password: "password"
+      - name: 'default'

--- a/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_2R/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_2R/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_2R/fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R/fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_2R/fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R/fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/ch-proxy/config/config.yml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/ch-proxy/config/config.yml
@@ -1,27 +1,25 @@
 server:
   http:
-    listen_addr: ":80"
-    allowed_networks: ["127.0.0.0/24", "192.168.9.0/24"]
+    listen_addr: ':80'
+    allowed_networks: ['127.0.0.0/24', '192.168.9.0/24']
 
 users:
-  - name: "admin_2S_2R"
-    password: "password"
-    to_cluster: "cluster_2S_2R"
-    to_user: "admin"
+  - name: 'admin_2S_2R'
+    to_cluster: 'cluster_2S_2R'
+    to_user: 'default'
     max_concurrent_queries: 100
     max_execution_time: 30s
     requests_per_minute: 10
     # Allow `CORS` requests for `tabix`.
     allow_cors: true
 clusters:
-  - name: "cluster_2S_2R"
+  - name: 'cluster_2S_2R'
     nodes:
       [
-        "clickhouse-01:8123",
-        "clickhouse-02:8123",
-        "clickhouse-03:8123",
-        "clickhouse-04:8123",
+        'clickhouse-01:8123',
+        'clickhouse-02:8123',
+        'clickhouse-03:8123',
+        'clickhouse-04:8123',
       ]
     users:
-      - name: "admin"
-        password: "password"
+      - name: 'default'

--- a/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>

--- a/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml
@@ -16,16 +16,11 @@
                 <ip>::/0</ip>
             </networks>
             <quota>default</quota>
-        </default>
-        <admin>
             <access_management>1</access_management>
-            <password>password</password>
-            <profile>default</profile>
-            <networks>
-                <ip>::/0</ip>
-            </networks>
-            <quota>default</quota>
-        </admin>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
     </users>
     <quotas>
         <default>


### PR DESCRIPTION
This PR aligns all the recipes to just embed a `default` user with no password configured and removes the `admin/password` pair.

Also required extra settings are added to allow `default` user to run `GRANT ALL`