### PR TITLE
[docker-compose][minio] S3 backed mergetree table

### DIFF
--- a/docker-compose-recipes/recipes/ch-and-minio-S3/README.md
+++ b/docker-compose-recipes/recipes/ch-and-minio-S3/README.md
@@ -1,3 +1,68 @@
 # ClickHouse and S3 Minio
 
 1 single ClickHouse Instance configured with 1 S3 Minio instance
+
+This recipe defines a S3 type disk pointing to the Minio S3 instance, a storage policy that makes use of the s3 disk and a MergeTree table backed by it.
+
+```
+ch_minio_s3 :) SELECT * FROM trips_s3 LIMIT 1 FORMAT Vertical
+
+SELECT *
+FROM trips_s3
+LIMIT 1
+FORMAT Vertical
+
+Query id: 32c7d679-183c-4d5c-a7b3-f5f0f567b23f
+
+Row 1:
+──────
+trip_id:           14
+pickup_date:       2013-08-02
+pickup_datetime:   2013-08-02 09:43:58
+dropoff_datetime:  2013-08-02 09:44:13
+pickup_longitude:  0
+pickup_latitude:   0
+dropoff_longitude: 0
+dropoff_latitude:  0
+passenger_count:   1
+trip_distance:     0
+tip_amount:        0
+total_amount:      2
+payment_type:      CSH
+
+1 row in set. Elapsed: 0.017 sec. Processed 1.06 thousand rows, 67.90 KB (61.98 thousand rows/s., 3.97 MB/s.)
+
+ch_minio_s3 :) SHOW CREATE TABLE trips_s3 FORMAT Vertical
+
+SHOW CREATE TABLE trips_s3
+FORMAT Vertical
+
+Query id: fa0571f7-e6b4-44aa-910a-9106d3e80a86
+
+Row 1:
+──────
+statement: CREATE TABLE default.trips_s3
+(
+    `trip_id` UInt32,
+    `pickup_date` Date,
+    `pickup_datetime` DateTime,
+    `dropoff_datetime` DateTime,
+    `pickup_longitude` Float64,
+    `pickup_latitude` Float64,
+    `dropoff_longitude` Float64,
+    `dropoff_latitude` Float64,
+    `passenger_count` UInt8,
+    `trip_distance` Float64,
+    `tip_amount` Float32,
+    `total_amount` Float32,
+    `payment_type` Enum8('UNK' = 0, 'CSH' = 1, 'CRE' = 2, 'NOC' = 3, 'DIS' = 4)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(pickup_date)
+ORDER BY pickup_datetime
+SETTINGS index_granularity = 8192, storage_policy = 's3_main'
+
+1 row in set. Elapsed: 0.003 sec.
+```
+
+

--- a/docker-compose-recipes/recipes/ch-and-minio-S3/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/ch-and-minio-S3/docker-compose.yaml
@@ -2,28 +2,30 @@ version: '3.8'
 services:
   clickhouse:
     image: clickhouse/clickhouse-server
-    user: "101:101"
+    user: '101:101'
     container_name: clickhouse
     hostname: clickhouse
     volumes:
       - ${PWD}/fs/volumes/clickhouse/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
       - ${PWD}/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ${PWD}/fs/volumes/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     ports:
-      - "127.0.0.1:8123:8123"
-      - "127.0.0.1:9000:9000"
+      - '127.0.0.1:8123:8123'
+      - '127.0.0.1:9000:9000'
     depends_on:
       - minio
+      - createbuckets
   minio:
     image: quay.io/minio/minio
     container_name: minio
     hostname: minio
     command: server --address 0.0.0.0:10000 --console-address 0.0.0.0:10001 /data
     ports:
-      - "127.0.0.1:10000:10000"
-      - "127.0.0.1:10001:10001"
+      - '127.0.0.1:10000:10000'
+      - '127.0.0.1:10001:10001'
     environment:
-      - MINIO_ACCESS_KEY=minioadmin
-      - MINIO_SECRET_KEY=minioadminpassword
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadminpassword
   createbuckets:
     image: minio/mc
     depends_on:

--- a/docker-compose-recipes/recipes/ch-and-minio-S3/fs/volumes/clickhouse/docker-entrypoint-initdb.d/00_create_s3_backed_mergetree_table.sh
+++ b/docker-compose-recipes/recipes/ch-and-minio-S3/fs/volumes/clickhouse/docker-entrypoint-initdb.d/00_create_s3_backed_mergetree_table.sh
@@ -1,0 +1,6 @@
+
+#!/bin/bash
+set -e 
+clickhouse client -n <<-EOSQL
+CREATE TABLE trips_s3 ( trip_id UInt32, pickup_date Date, pickup_datetime DateTime, dropoff_datetime DateTime, pickup_longitude Float64, pickup_latitude Float64, dropoff_longitude Float64, dropoff_latitude Float64, passenger_count UInt8, trip_distance Float64, tip_amount Float32, total_amount Float32, payment_type Enum8( 'UNK' = 0, 'CSH' = 1, 'CRE' = 2, 'NOC' = 3, 'DIS' = 4 ) ) ENGINE = MergeTree PARTITION BY toYYYYMM(pickup_date) ORDER BY pickup_datetime SETTINGS index_granularity = 8192, storage_policy = 's3_main';
+EOSQL

--- a/docker-compose-recipes/recipes/ch-and-minio-S3/fs/volumes/clickhouse/docker-entrypoint-initdb.d/01_insert_into_s3_backed_mergetree_table.sh
+++ b/docker-compose-recipes/recipes/ch-and-minio-S3/fs/volumes/clickhouse/docker-entrypoint-initdb.d/01_insert_into_s3_backed_mergetree_table.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+clickhouse client -n <<-EOSQL
+INSERT INTO trips_s3 SELECT trip_id, pickup_date, pickup_datetime, dropoff_datetime, pickup_longitude, pickup_latitude, dropoff_longitude, dropoff_latitude, passenger_count, trip_distance, tip_amount, total_amount, payment_type FROM s3('https://ch-nyc-taxi.s3.eu-west-3.amazonaws.com/tsv/trips_{0..9}.tsv.gz','TabSeparatedWithNames') LIMIT 1000000;
+EOSQL

--- a/docker-compose-recipes/recipes/ch-and-minio-S3/fs/volumes/clickhouse/etc/clickhouse-server/config.d/config.xml
+++ b/docker-compose-recipes/recipes/ch-and-minio-S3/fs/volumes/clickhouse/etc/clickhouse-server/config.d/config.xml
@@ -36,13 +36,13 @@
             </s3_cache>
         </disks>
         <policies>
-            <s3only>
+            <s3_main>
                 <volumes>
                     <s3>
                         <disk>s3</disk>
                     </s3>
                 </volumes>
-            </s3only>
+            </s3_main>
         </policies>
     </storage_configuration>
 </clickhouse>

--- a/docker-compose-recipes/recipes/ch-and-openldap/README.md
+++ b/docker-compose-recipes/recipes/ch-and-openldap/README.md
@@ -172,4 +172,4 @@ When authenticating with user `bob` and `alice` in ClickHouse, you will see in t
 
 The documentation for ClickHouse and LDAP is available in the [ClickHouse documentation](https://clickhouse.com/docs/en/guides/sre/configuring-ldap).
 
-If you would like to contribute to this example, please open an issue in this repo.  Thanks in advance for your contribution!
+If you would like to contribute to this example, please file a PR in this repo.  Thanks in advance for your contribution!


### PR DESCRIPTION
This PR updates the Minio recipe:

- replaces deprecated Minio env vars
- creates s3 backed table in clickhouse
- populates the table with public s3 data
- updates the relevant readme file