### PR TITLE
[docker-recipes][cluster_2S_2R_auth] Add interserver auth

### DIFF
--- a/docker-compose-recipes/recipes/cluster_2S_2R_auth/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_auth/README.md
@@ -8,7 +8,8 @@
 
 This recipe implements also:
 
-- cluster inter-nodes authentication (`<secret>`)
+- cluster inter-nodes authentication for distributed queries (`<secret>`)
+- cluster interserver http channel for low-level replication (`<interserver_http_credentials>`)
 - keeper authentication through auth digest scheme (`<identity>`)
 
 By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper

--- a/docker-compose-recipes/recipes/cluster_2S_2R_auth/fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_auth/fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml
@@ -10,6 +10,10 @@
   <listen_host>0.0.0.0</listen_host>
   <http_port>8123</http_port>
   <tcp_port>9000</tcp_port>
+  <interserver_http_credentials>
+    <user>interserver</user>
+    <password>password</password>
+  </interserver_http_credentials>
   <user_directories>
     <users_xml>
       <path>users.xml</path>

--- a/docker-compose-recipes/recipes/cluster_2S_2R_auth/fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_auth/fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml
@@ -10,6 +10,10 @@
   <listen_host>0.0.0.0</listen_host>
   <http_port>8123</http_port>
   <tcp_port>9000</tcp_port>
+  <interserver_http_credentials>
+    <user>interserver</user>
+    <password>password</password>
+  </interserver_http_credentials>
   <user_directories>
     <users_xml>
       <path>users.xml</path>

--- a/docker-compose-recipes/recipes/cluster_2S_2R_auth/fs/volumes/clickhouse-03/etc/clickhouse-server/config.d/config.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_auth/fs/volumes/clickhouse-03/etc/clickhouse-server/config.d/config.xml
@@ -10,6 +10,10 @@
   <listen_host>0.0.0.0</listen_host>
   <http_port>8123</http_port>
   <tcp_port>9000</tcp_port>
+  <interserver_http_credentials>
+    <user>interserver</user>
+    <password>password</password>
+  </interserver_http_credentials>
   <user_directories>
     <users_xml>
       <path>users.xml</path>

--- a/docker-compose-recipes/recipes/cluster_2S_2R_auth/fs/volumes/clickhouse-04/etc/clickhouse-server/config.d/config.xml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_auth/fs/volumes/clickhouse-04/etc/clickhouse-server/config.d/config.xml
@@ -10,6 +10,10 @@
   <listen_host>0.0.0.0</listen_host>
   <http_port>8123</http_port>
   <tcp_port>9000</tcp_port>
+  <interserver_http_credentials>
+    <user>interserver</user>
+    <password>password</password>
+  </interserver_http_credentials>
   <user_directories>
     <users_xml>
       <path>users.xml</path>


### PR DESCRIPTION
This PR completes the missing level of authentication to interserver communication.

This is required for replication between nodes to occur in an [authenticated fashion](https://github.com/ClickHouse/ClickHouse/blob/master/programs/server/config.xml#L193).

