### PR TITLE
Add clustering to bigquery create.sql statement

### DIFF
--- a/blog-examples/Bench2Cost/bigquery/clickbench/bigquery_extended/create.sql
+++ b/blog-examples/Bench2Cost/bigquery/clickbench/bigquery_extended/create.sql
@@ -105,4 +105,5 @@ CREATE TABLE test.hits
     RefererHash BIGINT NOT NULL,
     URLHash BIGINT NOT NULL,
     CLID INTEGER NOT NULL
-);
+)
+CLUSTER BY CounterID, EventDate, UserID, EventTime;


### PR DESCRIPTION
This PR updates the BigQuery create.sql statement to include clustering.

Clustering is already enabled across our other database environments and provides a significant performance improvement. Adding it to BigQuery aligns our configurations and optimizes query performance.

References & Context
For comparison, here are the equivalent implementations where clustering is already enabled in other systems:

Snowflake: [create.sql](https://www.google.com/search?q=https://github.com/ClickHouse/examples/blob/main/blog-examples/Bench2Cost/snowflake/clickbench/create.sql)

ClickHouse: [create.sql](https://www.google.com/search?q=https://github.com/ClickHouse/examples/blob/main/blog-examples/Bench2Cost/clickhouse-cloud/clickbench/large/create.sql)

Redshift: [create.sql](https://www.google.com/search?q=https://github.com/ClickHouse/examples/blob/main/blog-examples/Bench2Cost/redshift-serverless/clickbench/redshift-serverless_extended/create.sql)

Databricks: [load_data.sql](https://www.google.com/search?q=https://github.com/ClickHouse/examples/blob/main/blog-examples/Bench2Cost/databricks/clickbench/load_data.sql)

Happy to run and update the actual numbers if that's helpful.