### PR TITLE
Add clustering to BigQuery create.sql statement

### DIFF
--- a/blog-examples/Bench2Cost/bigquery/clickbench/bigquery_extended/create.sql
+++ b/blog-examples/Bench2Cost/bigquery/clickbench/bigquery_extended/create.sql
@@ -105,4 +105,5 @@ CREATE TABLE test.hits
     RefererHash BIGINT NOT NULL,
     URLHash BIGINT NOT NULL,
     CLID INTEGER NOT NULL
-);
+)
+CLUSTER BY CounterID, EventDate, UserID, EventTime;


### PR DESCRIPTION
Add clustering into BigQuery's `create.sql` statement. 

Clustering is enabled everywhere else, and makes a big difference in BigQuery as well. Here are samples from other places:

* **Snowflake:** [create.sql](https://github.com/ClickHouse/examples/blob/main/blog-examples/Bench2Cost/snowflake/clickbench/create.sql)
* **Clickhouse:** [create.sql](https://github.com/ClickHouse/examples/blob/main/blog-examples/Bench2Cost/clickhouse-cloud/clickbench/large/create.sql)
* **Redshift:** [create.sql](https://github.com/ClickHouse/examples/blob/main/blog-examples/Bench2Cost/redshift-serverless/clickbench/redshift-serverless_extended/create.sql)
* **Databricks:** [load_data.sql](https://github.com/ClickHouse/examples/blob/main/blog-examples/Bench2Cost/databricks/clickbench/load_data.sql)