### PR TITLE
Add agentic SLA-breach scaling example (ai/clickhousectl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,8 @@ Examples cover a range of topics, from ClickHouse internals to integrating with 
 ## Repo contents
 
 - [blog-examples](./blog-examples/): Resources that support the [ClickHouse Blog](clickhouse.com/blog).
-- [docker-compose-recipes](./docker-compose-recipes/README.md): Various docker compose recipes for spinning up ClickHouse and common integrations, like Kafka, Grafana, Dagster and more.
-- [ethereum](./ethereum/README.md): Examples for working with Ethereum blockchain data, including table schemas, batch and streaming load examples, and various queries.
-- [learn-clickhouse-with-mark](./learn-clickhouse-with-mark/README.md): A collection of resources for learning ClickHouse from Mark Needham.
+- [ai](./ai/): Examples using AI with ClickHouse via clickhousectl and mcp
+- [LearnClickHouseWithMark](./LearnClickHouseWithMark/README.md): A collection of resources for learning ClickHouse from Mark Needham.
 
 ## Contributing
 
@@ -34,7 +33,3 @@ If there's an example you'd love to see, feel free to open an issue to request i
 
 - All examples should be self-contained, including documentation to use the example without relying on external resources (i.e., include a full README.md in the repo and do not just link to an external article).
 - Directories and files should use kebab-case.
-
-### ClickHouse employees
-
-The [blog-examples](./blog-examples/) directory contains resources that support the [ClickHouse Blog](clickhouse.com/blog). If you are writing a blog post and want to store resources in this repo, add a new directory here and follow the same standards and conventions as other examples in this repo.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ Examples cover a range of topics, from ClickHouse internals to integrating with 
 
 ## Repo contents
 
+- [ai](./ai/): Examples using AI with ClickHouse via clickhousectl and mcp.
 - [blog-examples](./blog-examples/): Resources that support the [ClickHouse Blog](clickhouse.com/blog).
-- [ai](./ai/): Examples using AI with ClickHouse via clickhousectl and mcp
+- [docker-compose-recipes](./docker-compose-recipes/README.md): Various docker compose recipes for spinning up ClickHouse and common integrations, like Kafka, Grafana, Dagster and more.
+- [ethereum](./ethereum/README.md): Examples for working with Ethereum blockchain data, including table schemas, batch and streaming load examples, and various queries.
 - [LearnClickHouseWithMark](./LearnClickHouseWithMark/README.md): A collection of resources for learning ClickHouse from Mark Needham.
 
 ## Contributing
@@ -33,3 +35,7 @@ If there's an example you'd love to see, feel free to open an issue to request i
 
 - All examples should be self-contained, including documentation to use the example without relying on external resources (i.e., include a full README.md in the repo and do not just link to an external article).
 - Directories and files should use kebab-case.
+
+### ClickHouse employees
+
+The [blog-examples](./blog-examples/) directory contains resources that support the [ClickHouse Blog](clickhouse.com/blog). If you are writing a blog post and want to store resources in this repo, add a new directory here and follow the same standards and conventions as other examples in this repo.

--- a/ai/README.md
+++ b/ai/README.md
@@ -3,3 +3,4 @@
 This part of the repository contains examples of using ClickHouse for AI.
 
 * [MCP Examples](https://github.com/ClickHouse/examples/tree/main/ai/mcp)
+* [clickhousectl Examples](https://github.com/ClickHouse/examples/tree/main/ai/clickhousectl)

--- a/ai/clickhousectl/.gitignore
+++ b/ai/clickhousectl/.gitignore
@@ -1,0 +1,1 @@
+config.env

--- a/ai/clickhousectl/README.md
+++ b/ai/clickhousectl/README.md
@@ -1,0 +1,20 @@
+# clickhousectl Examples
+
+Examples that use [`clickhousectl`](https://github.com/ClickHouse/clickhousectl) — the
+ClickHouse command-line control plane for managing local and Cloud services —
+to build agentic workflows around ClickHouse.
+
+## Cloning the repository
+
+If you want to run these examples locally, you'll need to first clone the repository:
+
+```
+git clone https://github.com/ClickHouse/examples.git
+cd examples/ai/clickhousectl
+```
+
+## Examples
+
+| Example | Description |
+|---------|-------------|
+| [Agentic SLA-breach detection and scaling](agentic-sla-scaling/README.md) | An AI agent that defends a query-latency SLA on ClickHouse Cloud: manufacture load, watch the SLA breach, then hand the breach to an agent that investigates the live system and applies the right scaling action — horizontal or vertical — on its own. |

--- a/ai/clickhousectl/README.md
+++ b/ai/clickhousectl/README.md
@@ -1,8 +1,6 @@
 # clickhousectl Examples
 
-Examples that use [`clickhousectl`](https://github.com/ClickHouse/clickhousectl) — the
-ClickHouse command-line control plane for managing local and Cloud services —
-to build agentic workflows around ClickHouse.
+Examples that use [`clickhousectl`](https://github.com/ClickHouse/clickhousectl), the ClickHouse CLI for managing local and Cloud services, to build agentic workflows around ClickHouse.
 
 ## Cloning the repository
 
@@ -17,4 +15,4 @@ cd examples/ai/clickhousectl
 
 | Example | Description |
 |---------|-------------|
-| [Agentic SLA-breach detection and scaling](agentic-sla-scaling/README.md) | An AI agent that defends a query-latency SLA on ClickHouse Cloud: manufacture load, watch the SLA breach, then hand the breach to an agent that investigates the live system and applies the right scaling action — horizontal or vertical — on its own. |
+| [Agentic SLA-breach detection and scaling](agentic-sla-scaling/README.md) | An AI agent that defends a query-latency SLA on ClickHouse Cloud: manufacture load, watch the SLA breach, then hand the breach to an agent that investigates the live system and applies the right scaling action (horizontal or vertical) on its own. |

--- a/ai/clickhousectl/agentic-sla-scaling/README.md
+++ b/ai/clickhousectl/agentic-sla-scaling/README.md
@@ -9,8 +9,8 @@ You generate load, watch the SLA breach, then hand the breach to the agent. The 
 | File | Role |
 |------|------|
 | `schema.sql` | A ~200M-row `events` table (CREATE & INSERT statements)|
-| `frontend.sh` | Simulates "frontend" traffic, sends ~4 light dashboard queries in flight, tagged `log_comment='frontend-dashboard'`. |
-| `load.sh` | Pressure generator using `clickhouse benchmark`. `horizontal` fires lots more of the same light query. `vertical` runs a different, heavy analytics query that pins CPU/memory. |
+| `frontend.sh` | Simulates "frontend" traffic, sends ~4 dashboard queries in flight, tagged `log_comment='frontend-dashboard'`. This is the SLA we defend. |
+| `load.sh` | Pressure generator using `clickhouse benchmark`. `horizontal` fires lots more of the same dashboard query. `vertical` runs a different, heavy analytics query that pins CPU/memory. |
 | `watch.sh` | Read-only watcher: prints the SLA p99 alongside the key resource-pressure metrics every 10s so you can see the breach and eyeball the cause. |
 | `investigate.sh` | Hands the breach to the agent (`claude -p`, scoped to `clickhousectl` only). The prompt states the breach and the available data sources. |
 
@@ -50,15 +50,19 @@ cp config.env.example config.env
 vim config.env # enter the details here
 source config.env
 
-# 3. Load data (~200M rows)
-clickhousectl cloud service query --id "$SERVICE_ID" --queries-file schema.sql
+# 3. Load data (~200M rows, ~100s). Use the native client, not the HTTP query
+#    API: the query API rejects multi-statement files and times out on the
+#    big INSERT.
+clickhouse client --host "$CH_HOST" --port "${CH_PORT:-9440}" --secure \
+  --user "${CH_USER:-default}" --password "$CH_PASSWORD" \
+  --queries-file schema.sql
 
 # 4. Three terminals (all: source config.env first)
 bash frontend.sh             # steady frontend traffic (the SLA)
 bash watch.sh                # SLA p99 + resource pressure, every 10s
-bash load.sh vertical 3      # scenario: resource contention -> expect VERTICAL
+bash load.sh vertical        # scenario: resource contention -> expect VERTICAL
 #   ...or...
-bash load.sh horizontal 40   # scenario: query concurrency  -> expect HORIZONTAL
+bash load.sh horizontal      # scenario: query concurrency  -> expect HORIZONTAL
 
 # 5. When watch.sh prints "<-- BREACH", hand off to the agent
 bash investigate.sh
@@ -68,3 +72,22 @@ clickhousectl cloud activity list   # the agent's scale action is in the audit l
 clickhousectl cloud service get "$SERVICE_ID" # view the service details to see the scale
 clickhousectl cloud service stop "$SERVICE_ID"   # tear it down
 ```
+
+## Tuning the breach
+
+The defaults are sized for the demo service above (8 GiB / ~2 vCPU, `SLA_MS=200`).
+The breach is driven by the dashboard query's fixed compute cost, which is
+cache-independent, so it should fire reliably — but if you change the service
+size, the SLA, or the data volume, you have two knobs:
+
+- **Concurrency** — pass it as the second arg: `bash load.sh vertical 8` or
+  `bash load.sh horizontal 384`. More concurrency = a deeper run queue = a
+  harder breach. The `horizontal` default (256) is tuned for the 8 GiB / ~2
+  vCPU service above; the dashboard query is individually cheap, so it takes a
+  few hundred in flight to saturate the query-thread pool. Watch `watch.sh`; if
+  p99 is climbing but not crossing the SLA, bump it.
+- **Per-query cost** — the `INTERVAL 1 DAY` window in the dashboard query
+  (`frontend.sh` _and_ the `horizontal` branch of `load.sh` — keep the two
+  byte-identical). A wider window scans and aggregates more rows, raising the
+  baseline cost so the breach lands at lower concurrency. The baseline (4 in
+  flight) should still sit comfortably under `SLA_MS`.

--- a/ai/clickhousectl/agentic-sla-scaling/README.md
+++ b/ai/clickhousectl/agentic-sla-scaling/README.md
@@ -1,0 +1,85 @@
+# Agentic SLA-breach detection and scaling
+
+A self-contained demo of an **agent that keeps a latency SLA**: a defended
+query-latency target on a ClickHouse Cloud service, a way to manufacture
+realistic pressure against it, and an AI agent that investigates a breach and
+applies the *right* scaling action — horizontal or vertical — on its own.
+
+There's no cron and no hard-coded answer. You generate load, watch the SLA
+breach, then hand the breach to the agent. The agent inspects the live system
+(`system.query_log`, Prometheus metrics) via [`clickhousectl`](https://github.com/ClickHouse/clickhousectl)
+and reasons its way to the correct lever.
+
+## How it works
+
+| File | Role |
+|------|------|
+| `schema.sql` | A ~200M-row `events` table. `ORDER BY (event_type, event_time)` is the lever: the dashboard query filters on `event_type` (hits the index → fast), while the heavy analytics query groups across all `user_id` (full scan → heavy). |
+| `frontend.sh` | Steady "frontend" traffic — ~4 light dashboard queries in flight, tagged `log_comment='frontend-dashboard'`. This is the SLA we defend. Runs over the native protocol via `clickhouse client`. |
+| `load.sh` | Pressure generator via native `clickhouse benchmark`. `horizontal` fires lots more of the *same* light query (concurrency pressure → scale out). `vertical` runs a *different*, heavy analytics query that pins CPU/memory (resource contention → scale up). |
+| `watch.sh` | Read-only watcher: prints the SLA p99 alongside the key resource-pressure metrics every 10s so you can see the breach and eyeball the cause. |
+| `investigate.sh` | Hands the breach to the agent (`claude -p`, scoped to `clickhousectl` only). The prompt states the breach and the available data sources and scaling levers, but **not** which scenario it's in — the agent has to work it out. |
+
+## Prereqs
+
+- [`clickhousectl`](https://github.com/ClickHouse/clickhousectl), authenticated against ClickHouse Cloud:
+  ```
+  clickhousectl cloud auth login --api-key ... --api-secret ...
+  ```
+- The `clickhouse` binary on your PATH. Install the latest and put it on the
+  path with:
+  ```
+  clickhousectl local use latest
+  ```
+  This provides `clickhouse client` (used by `frontend.sh`) and
+  `clickhouse benchmark` (used by `load.sh`). Both run over the native protocol
+  rather than HTTP, which gets rate-limited under sustained fan-out.
+- The [`claude` CLI](https://docs.claude.com/en/docs/claude-code/overview), plus the ClickHouse agent skills:
+  ```
+  clickhousectl skills --agent claude
+  ```
+
+## Run it
+
+```bash
+# 1. Create the service (this costs money until you stop/delete it)
+clickhousectl cloud service create --name sla-demo \
+  --provider aws --region us-east-1 \
+  --min-replica-memory-gb 8 --max-replica-memory-gb 8 \
+  --num-replicas 1 --idle-scaling false
+
+# 2. Fill in connection details
+clickhousectl cloud service list                          # grab the SERVICE_ID
+clickhousectl cloud service get "$SERVICE_ID"             # native host/port
+clickhousectl cloud service reset-password "$SERVICE_ID"  # default-user password
+cp config.env.example config.env && $EDITOR config.env
+source config.env
+
+# 3. Load data (~200M rows)
+clickhousectl cloud service query --id "$SERVICE_ID" --queries-file schema.sql
+
+# 4. Three terminals (all: source config.env first)
+bash frontend.sh             # steady frontend traffic (the SLA)
+bash watch.sh                # SLA p99 + resource pressure, every 10s
+bash load.sh vertical 3      # scenario: resource contention -> expect VERTICAL
+#   ...or...
+bash load.sh horizontal 40   # scenario: query concurrency  -> expect HORIZONTAL
+
+# 5. When watch.sh prints "<-- BREACH", hand off to the agent
+bash investigate.sh
+
+# 6. Confirm + tear down
+clickhousectl cloud activity list   # the agent's scale action is in the audit log
+clickhousectl cloud service scale "$SERVICE_ID" \
+  --num-replicas 1 --min-replica-memory-gb 8 --max-replica-memory-gb 8
+clickhousectl cloud service stop "$SERVICE_ID"   # or delete
+```
+
+## Tuning notes
+
+- 8GB ≈ 2 vCPU, so the `vertical` scenario breaches fast. Ramp its concurrency
+  up until `CGroupMemoryUsed` pins near the limit but queries don't OOM — an
+  OOM'd query errors instead of slowing the frontend, which muddies the SLA.
+- The `horizontal` scenario keeps memory low; raise concurrency until queries
+  queue and the frontend p99 climbs from *waiting*, not from *work*.
+- Re-run a scenario after the agent scales to confirm the SLA recovers.

--- a/ai/clickhousectl/agentic-sla-scaling/README.md
+++ b/ai/clickhousectl/agentic-sla-scaling/README.md
@@ -1,58 +1,53 @@
 # Agentic SLA-breach detection and scaling
 
-A self-contained demo of an **agent that keeps a latency SLA**: a defended
-query-latency target on a ClickHouse Cloud service, a way to manufacture
-realistic pressure against it, and an AI agent that investigates a breach and
-applies the *right* scaling action — horizontal or vertical — on its own.
+A demo of an agent that keeps a latency SLA: a defended query-latency target on a ClickHouse Cloud service, a way to manufacture realistic pressure against it, and an AI agent that investigates a breach and applies the right scaling action — horizontal or vertical — on its own.
 
-There's no cron and no hard-coded answer. You generate load, watch the SLA
-breach, then hand the breach to the agent. The agent inspects the live system
-(`system.query_log`, Prometheus metrics) via [`clickhousectl`](https://github.com/ClickHouse/clickhousectl)
-and reasons its way to the correct lever.
+You generate load, watch the SLA breach, then hand the breach to the agent. The agent inspects the live system (`system.query_log`, Prometheus metrics) via [`clickhousectl`](https://github.com/ClickHouse/clickhousectl) and reasons its way to the correct lever.
 
 ## How it works
 
 | File | Role |
 |------|------|
-| `schema.sql` | A ~200M-row `events` table. `ORDER BY (event_type, event_time)` is the lever: the dashboard query filters on `event_type` (hits the index → fast), while the heavy analytics query groups across all `user_id` (full scan → heavy). |
-| `frontend.sh` | Steady "frontend" traffic — ~4 light dashboard queries in flight, tagged `log_comment='frontend-dashboard'`. This is the SLA we defend. Runs over the native protocol via `clickhouse client`. |
-| `load.sh` | Pressure generator via native `clickhouse benchmark`. `horizontal` fires lots more of the *same* light query (concurrency pressure → scale out). `vertical` runs a *different*, heavy analytics query that pins CPU/memory (resource contention → scale up). |
+| `schema.sql` | A ~200M-row `events` table (CREATE & INSERT statements)|
+| `frontend.sh` | Simulates "frontend" traffic, sends ~4 light dashboard queries in flight, tagged `log_comment='frontend-dashboard'`. |
+| `load.sh` | Pressure generator using `clickhouse benchmark`. `horizontal` fires lots more of the same light query. `vertical` runs a different, heavy analytics query that pins CPU/memory. |
 | `watch.sh` | Read-only watcher: prints the SLA p99 alongside the key resource-pressure metrics every 10s so you can see the breach and eyeball the cause. |
-| `investigate.sh` | Hands the breach to the agent (`claude -p`, scoped to `clickhousectl` only). The prompt states the breach and the available data sources and scaling levers, but **not** which scenario it's in — the agent has to work it out. |
+| `investigate.sh` | Hands the breach to the agent (`claude -p`, scoped to `clickhousectl` only). The prompt states the breach and the available data sources. |
 
 ## Prereqs
 
-- [`clickhousectl`](https://github.com/ClickHouse/clickhousectl), authenticated against ClickHouse Cloud:
+- [`clickhousectl`](https://github.com/ClickHouse/clickhousectl) installed:
+  ```
+  curl https://clickhouse.com/cli | sh
+  ```
+- `clickhousectl` authenticated against ClickHouse Cloud:
   ```
   clickhousectl cloud auth login --api-key ... --api-secret ...
   ```
-- The `clickhouse` binary on your PATH. Install the latest and put it on the
-  path with:
+- The `clickhouse` binary on your PATH. Install the latest and put it on the path with:
   ```
   clickhousectl local use latest
   ```
-  This provides `clickhouse client` (used by `frontend.sh`) and
-  `clickhouse benchmark` (used by `load.sh`). Both run over the native protocol
-  rather than HTTP, which gets rate-limited under sustained fan-out.
-- The [`claude` CLI](https://docs.claude.com/en/docs/claude-code/overview), plus the ClickHouse agent skills:
+  This provides `clickhouse client` (used by `frontend.sh`) and `clickhouse benchmark` (used by `load.sh`).
+- [Claude Code](https://docs.claude.com/en/docs/claude-code/overview), plus the ClickHouse agent skills:
   ```
   clickhousectl skills --agent claude
   ```
 
 ## Run it
 
+Run through these steps (or, just ask Claude to do it for you):
+
 ```bash
-# 1. Create the service (this costs money until you stop/delete it)
+# 1. Create the service
 clickhousectl cloud service create --name sla-demo \
-  --provider aws --region us-east-1 \
+  --provider aws --region eu-west-1 \
   --min-replica-memory-gb 8 --max-replica-memory-gb 8 \
   --num-replicas 1 --idle-scaling false
 
-# 2. Fill in connection details
-clickhousectl cloud service list                          # grab the SERVICE_ID
-clickhousectl cloud service get "$SERVICE_ID"             # native host/port
-clickhousectl cloud service reset-password "$SERVICE_ID"  # default-user password
-cp config.env.example config.env && $EDITOR config.env
+# 2. Fill in connection details using the output of the first command (service id, host, port, default-user pass)
+cp config.env.example config.env
+vim config.env # enter the details here
 source config.env
 
 # 3. Load data (~200M rows)
@@ -70,16 +65,6 @@ bash investigate.sh
 
 # 6. Confirm + tear down
 clickhousectl cloud activity list   # the agent's scale action is in the audit log
-clickhousectl cloud service scale "$SERVICE_ID" \
-  --num-replicas 1 --min-replica-memory-gb 8 --max-replica-memory-gb 8
-clickhousectl cloud service stop "$SERVICE_ID"   # or delete
+clickhousectl cloud service get "$SERVICE_ID" # view the service details to see the scale
+clickhousectl cloud service stop "$SERVICE_ID"   # tear it down
 ```
-
-## Tuning notes
-
-- 8GB ≈ 2 vCPU, so the `vertical` scenario breaches fast. Ramp its concurrency
-  up until `CGroupMemoryUsed` pins near the limit but queries don't OOM — an
-  OOM'd query errors instead of slowing the frontend, which muddies the SLA.
-- The `horizontal` scenario keeps memory low; raise concurrency until queries
-  queue and the frontend p99 climbs from *waiting*, not from *work*.
-- Re-run a scenario after the agent scales to confirm the SLA recovers.

--- a/ai/clickhousectl/agentic-sla-scaling/config.env.example
+++ b/ai/clickhousectl/agentic-sla-scaling/config.env.example
@@ -1,8 +1,5 @@
 # Copy to config.env and fill in, then: source config.env
-# SERVICE_ID + the native endpoint are shown by:
-#   clickhousectl cloud service get --id "$SERVICE_ID"
-# The default-user password comes from:
-#   clickhousectl cloud service reset-password "$SERVICE_ID"
+# These details are returned by the initial service creation step
 
 export SERVICE_ID=""          # e.g. abc123de-...
 export CH_HOST=""             # native endpoint host, e.g. xxxx.us-east-1.aws.clickhouse.cloud

--- a/ai/clickhousectl/agentic-sla-scaling/config.env.example
+++ b/ai/clickhousectl/agentic-sla-scaling/config.env.example
@@ -1,0 +1,12 @@
+# Copy to config.env and fill in, then: source config.env
+# SERVICE_ID + the native endpoint are shown by:
+#   clickhousectl cloud service get --id "$SERVICE_ID"
+# The default-user password comes from:
+#   clickhousectl cloud service reset-password "$SERVICE_ID"
+
+export SERVICE_ID=""          # e.g. abc123de-...
+export CH_HOST=""             # native endpoint host, e.g. xxxx.us-east-1.aws.clickhouse.cloud
+export CH_PORT=9440           # native secure port
+export CH_USER=default
+export CH_PASSWORD=""         # from reset-password
+export SLA_MS=200

--- a/ai/clickhousectl/agentic-sla-scaling/frontend.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/frontend.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Steady "frontend" traffic: ~4 light, selective queries in flight, tagged
+# log_comment='frontend-dashboard'. This is the SLA we defend.
+# query_duration_ms in query_log is server-side only, so CLI startup cost
+# does not pollute the measured latency.
+set -euo pipefail
+: "${CH_HOST:?source config.env first}" "${CH_PASSWORD:?}"
+
+Q="SELECT event_type,count(),avg(value) FROM events
+   WHERE event_type='purchase' AND event_time>now()-INTERVAL 1 HOUR
+   GROUP BY event_type SETTINGS log_comment='frontend-dashboard'"
+
+# Native protocol via `clickhouse client` (same connection details as
+# load.sh) — the HTTP endpoint that `clickhousectl cloud service query` uses
+# gets rate-limited under this steady fan-out.
+echo "frontend traffic -> ${CH_HOST} (ctrl-c to stop)"
+while true; do
+  seq 4 | xargs -P4 -I{} clickhouse client \
+    --host "$CH_HOST" --port "${CH_PORT:-9440}" --secure \
+    --user "${CH_USER:-default}" --password "$CH_PASSWORD" \
+    --format Null --query "$Q" || true
+  sleep 1
+done

--- a/ai/clickhousectl/agentic-sla-scaling/frontend.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/frontend.sh
@@ -10,9 +10,6 @@ Q="SELECT event_type,count(),avg(value) FROM events
    WHERE event_type='purchase' AND event_time>now()-INTERVAL 1 HOUR
    GROUP BY event_type SETTINGS log_comment='frontend-dashboard'"
 
-# Native protocol via `clickhouse client` (same connection details as
-# load.sh) — the HTTP endpoint that `clickhousectl cloud service query` uses
-# gets rate-limited under this steady fan-out.
 echo "frontend traffic -> ${CH_HOST} (ctrl-c to stop)"
 while true; do
   seq 4 | xargs -P4 -I{} clickhouse client \

--- a/ai/clickhousectl/agentic-sla-scaling/frontend.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/frontend.sh
@@ -1,13 +1,24 @@
 #!/usr/bin/env bash
-# Steady "frontend" traffic: ~4 light, selective queries in flight, tagged
+# Steady "frontend" traffic: ~4 dashboard queries in flight, tagged
 # log_comment='frontend-dashboard'. This is the SLA we defend.
 # query_duration_ms in query_log is server-side only, so CLI startup cost
 # does not pollute the measured latency.
+#
+# The query is selective (event_type uses the index) but scans a multi-day
+# window and aggregates it, so each run costs a steady ~tens of ms of CPU
+# that does NOT depend on the page cache being warm. That fixed compute cost
+# is what makes the breaches reliable: under CPU contention it stretches well
+# past the SLA, and a moderate number of concurrent copies saturate the box.
+# Baseline (4 in flight) sits well under SLA_MS; the load scripts push it over.
+#
+# IMPORTANT: keep this query byte-identical to the 'horizontal' query in
+# load.sh — the horizontal scenario is "the same dashboard query, just lots
+# more of it".
 set -euo pipefail
 : "${CH_HOST:?source config.env first}" "${CH_PASSWORD:?}"
 
-Q="SELECT event_type,count(),avg(value) FROM events
-   WHERE event_type='purchase' AND event_time>now()-INTERVAL 1 HOUR
+Q="SELECT event_type,count(),avg(value),quantile(0.9)(value) FROM events
+   WHERE event_type='purchase' AND event_time>now()-INTERVAL 1 DAY
    GROUP BY event_type SETTINGS log_comment='frontend-dashboard'"
 
 echo "frontend traffic -> ${CH_HOST} (ctrl-c to stop)"

--- a/ai/clickhousectl/agentic-sla-scaling/investigate.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/investigate.sh
@@ -6,11 +6,6 @@
 # would otherwise swallow a positional prompt). We scope the agent to
 # clickhousectl only.
 #
-# The prompt deliberately does NOT tell the agent which scenario it's in or what
-# to query. It states the breach, points at the available data sources and the
-# two scaling levers, and gives the general principle behind each lever. The
-# agent has to investigate the live system and reason its way to horizontal vs
-# vertical on its own — that's the demo.
 set -euo pipefail
 : "${SERVICE_ID:?source config.env first}"
 SLA_MS="${SLA_MS:-200}"

--- a/ai/clickhousectl/agentic-sla-scaling/investigate.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/investigate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Hand the breach to the agent. Run this once watch.sh shows a breach.
+# Install skills first (one-time):  clickhousectl skills --agent claude
+#
+# Prompt is piped via stdin (claude's --allowedTools is variadic/greedy and
+# would otherwise swallow a positional prompt). We scope the agent to
+# clickhousectl only.
+#
+# The prompt deliberately does NOT tell the agent which scenario it's in or what
+# to query. It states the breach, points at the available data sources and the
+# two scaling levers, and gives the general principle behind each lever. The
+# agent has to investigate the live system and reason its way to horizontal vs
+# vertical on its own — that's the demo.
+set -euo pipefail
+: "${SERVICE_ID:?source config.env first}"
+SLA_MS="${SLA_MS:-200}"
+
+p99=$(clickhousectl cloud service query --id "$SERVICE_ID" --format TSV --query "
+  SELECT round(quantile(0.99)(query_duration_ms))
+  FROM clusterAllReplicas(default, system.query_log)
+  WHERE event_time > now() - INTERVAL 1 MINUTE
+    AND type='QueryFinish' AND log_comment='frontend-dashboard'")
+
+read -r -d '' PROMPT <<EOF || true
+The 'frontend-dashboard' query latency SLA on ClickHouse Cloud service $SERVICE_ID
+has just breached: p99 over the last minute is ${p99}ms against a ${SLA_MS}ms target.
+
+You're the on-call agent. Work out WHY the SLA is breaching, then remediate it by
+applying exactly one scaling action to the service. Let the evidence drive the choice.
+
+What you have to work with (clickhousectl only):
+  - SQL against the service's system tables:
+      clickhousectl cloud service query --id $SERVICE_ID --format TSV --query "<SQL>"
+    system.query_log is the richest source — one row per executed query, with its
+    timing and memory use, and each query tagged with the workload it belongs to in
+    the log_comment column ('frontend-dashboard' is the SLA workload). Filter to
+    type='QueryFinish' for completed queries; use clusterAllReplicas to see all
+    replicas.
+  - Live resource pressure from Prometheus (CPU, memory against the per-replica
+    limit, query concurrency, background merges):
+      clickhousectl cloud service prometheus $SERVICE_ID --filtered-metrics true
+
+Your two scaling levers — apply only ONE, whichever the root cause calls for:
+  - Change the replica count:
+      clickhousectl cloud service scale $SERVICE_ID --num-replicas N
+  - Change the size (memory) of each replica:
+      clickhousectl cloud service scale $SERVICE_ID --min-replica-memory-gb M --max-replica-memory-gb M
+
+General advice on which scaling pattern to use:
+- Prefer scaling vertically if cause is unclear.
+- Scale vertically if latency is likely caused by resource contention from other queries.
+- Scale horizontally if latency is caused by an increase in query concurrency or write throughput.
+
+Apply one action, then explain the evidence you relied on and why that lever fits.
+EOF
+
+printf '%s' "$PROMPT" | claude -p --model haiku --allowedTools "Bash(clickhousectl:*)"

--- a/ai/clickhousectl/agentic-sla-scaling/investigate.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/investigate.sh
@@ -49,4 +49,4 @@ General advice on which scaling pattern to use:
 Apply one action, then explain the evidence you relied on and why that lever fits.
 EOF
 
-printf '%s' "$PROMPT" | claude -p --model haiku --allowedTools "Bash(clickhousectl:*)"
+printf '%s' "$PROMPT" | claude -p --model sonnet --allowedTools "Bash(clickhousectl:*)"

--- a/ai/clickhousectl/agentic-sla-scaling/load.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/load.sh
@@ -19,18 +19,29 @@ set -euo pipefail
 MODE="${1:-vertical}"; C="${2:-}"
 case "$MODE" in
   horizontal)
-     C="${C:-40}"
-     # The SAME dashboard query as frontend.sh — just lots more of it.
-     Q="SELECT event_type,count(),avg(value) FROM events
-        WHERE event_type='purchase' AND event_time>now()-INTERVAL 1 HOUR
+     C="${C:-256}"
+     # The SAME dashboard query as frontend.sh — just lots more of it, fired
+     # back-to-back. Each query is individually cheap (a few ms; it scans a
+     # 1-day window via the index), so it takes a lot of them in flight to
+     # saturate the ~2-core replica's query-thread pool. Once the queue gets
+     # deep enough the dashboard p99 climbs past the SLA. The cost is compute,
+     # not disk I/O, so this breaches the same whether the page cache is cold
+     # or warm. The signal in query_log is a high RATE of the (cheap,
+     # low-memory) dashboard query -> add replicas.
+     # Keep this byte-identical to the query in frontend.sh.
+     Q="SELECT event_type,count(),avg(value),quantile(0.9)(value) FROM events
+        WHERE event_type='purchase' AND event_time>now()-INTERVAL 1 DAY
         GROUP BY event_type SETTINGS log_comment='frontend-dashboard'"
      EXTRA="-d 0";;        # delay 0: fire as fast as possible
   vertical)
-     C="${C:-3}"
+     C="${C:-4}"
      # Separate heavy analytics job: full-scan + per-row trig, grouped by user.
-     # CPU-bound and memory-bounded (won't OOM the 8 GiB box). At c=3 on a
-     # ~2-core replica it pins CPU and starves the dashboard, while the
-     # dashboard's OWN arrival rate stays at baseline -> the fix is a bigger box.
+     # CPU- and memory-hungry, but bounded (won't OOM the 8 GiB box). Even a
+     # handful in flight pin CPU on the ~2-core replica and starve every other
+     # query of cycles, so the dashboard query's steady compute cost balloons
+     # well past the SLA -- while the dashboard's OWN arrival rate stays at
+     # baseline. The signal in query_log is a single heavy query type burning
+     # CPU/memory at low QPS -> the fix is a bigger box.
      Q="SELECT user_id, count(), avg(sin(value) + cos(value)) FROM events
         GROUP BY user_id ORDER BY 2 DESC LIMIT 20
         SETTINGS log_comment='analytics-batch'"

--- a/ai/clickhousectl/agentic-sla-scaling/load.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/load.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Pressure generator via native `clickhouse benchmark`.
+#
+#   ./load.sh horizontal [concurrency]
+#       The SAME dashboard query, but from many more users (high QPS of the
+#       light query). Inflates the monitored 'frontend-dashboard' rate; memory
+#       stays low. Correct fix: HORIZONTAL (more replicas to serve the volume).
+#
+#   ./load.sh vertical [concurrency]
+#       A DIFFERENT, heavy analytics workload ('analytics-batch') that pins
+#       CPU/memory at low concurrency while the dashboard rate stays at its
+#       baseline. Correct fix: VERTICAL (a bigger replica).
+#
+# Run the steady baseline (frontend.sh) alongside BOTH so there is always a
+# normal stream of dashboard queries whose p99 is the SLA.
+set -euo pipefail
+: "${CH_HOST:?source config.env first}" "${CH_PASSWORD:?}"
+
+MODE="${1:-vertical}"; C="${2:-}"
+case "$MODE" in
+  horizontal)
+     C="${C:-40}"
+     # The SAME dashboard query as frontend.sh — just lots more of it.
+     Q="SELECT event_type,count(),avg(value) FROM events
+        WHERE event_type='purchase' AND event_time>now()-INTERVAL 1 HOUR
+        GROUP BY event_type SETTINGS log_comment='frontend-dashboard'"
+     EXTRA="-d 0";;        # delay 0: fire as fast as possible
+  vertical)
+     C="${C:-3}"
+     # Separate heavy analytics job: full-scan + per-row trig, grouped by user.
+     # CPU-bound and memory-bounded (won't OOM the 8 GiB box). At c=3 on a
+     # ~2-core replica it pins CPU and starves the dashboard, while the
+     # dashboard's OWN arrival rate stays at baseline -> the fix is a bigger box.
+     Q="SELECT user_id, count(), avg(sin(value) + cos(value)) FROM events
+        GROUP BY user_id ORDER BY 2 DESC LIMIT 20
+        SETTINGS log_comment='analytics-batch'"
+     EXTRA="";;
+  *) echo "usage: $0 horizontal|vertical [concurrency]" >&2; exit 1;;
+esac
+
+echo "scenario $MODE, concurrency=$C (ctrl-c to stop)"
+clickhouse benchmark \
+  --host "$CH_HOST" --port "${CH_PORT:-9440}" --secure \
+  --user "${CH_USER:-default}" --password "$CH_PASSWORD" \
+  -c "$C" $EXTRA \
+  --query "$Q"

--- a/ai/clickhousectl/agentic-sla-scaling/schema.sql
+++ b/ai/clickhousectl/agentic-sla-scaling/schema.sql
@@ -1,4 +1,4 @@
--- ~200M row events table. ORDER BY (event_type, event_time) is the lever:
+-- ~200M row events table.
 -- the frontend query filters on event_type (uses the index -> fast),
 -- the load query groups across all user_id (full scan -> heavy).
 

--- a/ai/clickhousectl/agentic-sla-scaling/schema.sql
+++ b/ai/clickhousectl/agentic-sla-scaling/schema.sql
@@ -1,0 +1,23 @@
+-- ~200M row events table. ORDER BY (event_type, event_time) is the lever:
+-- the frontend query filters on event_type (uses the index -> fast),
+-- the load query groups across all user_id (full scan -> heavy).
+
+CREATE TABLE IF NOT EXISTS events
+(
+    event_time  DateTime,
+    user_id     UInt32,
+    event_type  LowCardinality(String),
+    country     LowCardinality(String),
+    value       Float64
+)
+ENGINE = MergeTree
+ORDER BY (event_type, event_time);
+
+INSERT INTO events
+SELECT
+    now() - toIntervalSecond(number % 2592000),
+    rand() % 1000000,
+    ['click','view','purchase','signup','scroll'][1 + number % 5],
+    ['US','GB','DE','FR','IN','BR'][1 + (number % 6)],
+    rand() / 1e6
+FROM numbers(200000000);

--- a/ai/clickhousectl/agentic-sla-scaling/watch.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/watch.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Read-only watcher (replaces the cron). Prints the SLA p99 and the key
+# resource-pressure metrics side by side so you can see the breach and
+# eyeball the root cause before handing off to the agent.
+set -euo pipefail
+: "${SERVICE_ID:?source config.env first}"
+SLA_MS="${SLA_MS:-200}"
+
+SLA="SELECT toUInt64(quantile(0.99)(query_duration_ms))
+     FROM clusterAllReplicas(default, system.query_log)
+     WHERE event_time > now() - INTERVAL 1 MINUTE
+       AND type='QueryFinish' AND log_comment='frontend-dashboard'"
+
+while true; do
+  p99=$(clickhousectl cloud service query --id "$SERVICE_ID" --format TSV --query "$SLA" 2>/dev/null || echo "?")
+  flag=""; [[ "$p99" =~ ^[0-9]+$ ]] && (( p99 > SLA_MS )) && flag="  <-- BREACH"
+  echo "[$(date +%T)] p99=${p99}ms (SLA ${SLA_MS}ms)${flag}"
+  clickhousectl cloud service prometheus "$SERVICE_ID" --filtered-metrics true 2>/dev/null \
+    | grep -E '^(ClickHouseMetrics_Query|ClickHouseAsyncMetrics_CGroupMemoryUsed|ClickHouseMetrics_BackgroundMergesAndMutationsPoolTask) ' \
+    | sed 's/^/    /'
+  sleep 10
+done

--- a/ai/clickhousectl/agentic-sla-scaling/watch.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/watch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Read-only watcher (replaces the cron). Prints the SLA p99 and the key
+# Read-only watcher. Prints the SLA p99 and the key
 # resource-pressure metrics side by side so you can see the breach and
 # eyeball the root cause before handing off to the agent.
 set -euo pipefail

--- a/ai/clickhousectl/agentic-sla-scaling/watch.sh
+++ b/ai/clickhousectl/agentic-sla-scaling/watch.sh
@@ -15,8 +15,12 @@ while true; do
   p99=$(clickhousectl cloud service query --id "$SERVICE_ID" --format TSV --query "$SLA" 2>/dev/null || echo "?")
   flag=""; [[ "$p99" =~ ^[0-9]+$ ]] && (( p99 > SLA_MS )) && flag="  <-- BREACH"
   echo "[$(date +%T)] p99=${p99}ms (SLA ${SLA_MS}ms)${flag}"
+  # Prometheus exposition format is `Name{labels} value` (labels optional), so
+  # match the metric name followed by either '{' or a space. Guard with
+  # `|| true` so a no-match grep (exit 1) doesn't trip `set -o pipefail` and
+  # kill the loop.
   clickhousectl cloud service prometheus "$SERVICE_ID" --filtered-metrics true 2>/dev/null \
-    | grep -E '^(ClickHouseMetrics_Query|ClickHouseAsyncMetrics_CGroupMemoryUsed|ClickHouseMetrics_BackgroundMergesAndMutationsPoolTask) ' \
-    | sed 's/^/    /'
+    | grep -E '^(ClickHouseMetrics_Query|ClickHouseAsyncMetrics_CGroupMemoryUsed|ClickHouseMetrics_BackgroundMergesAndMutationsPoolTask)[ {]' \
+    | sed 's/^/    /' || true
   sleep 10
 done


### PR DESCRIPTION
Adds an example under `ai/clickhousectl/agentic-sla-scaling`: an AI agent that defends a query-latency SLA on a ClickHouse Cloud service. You generate load, watch the SLA breach, then hand the breach to an agent (`claude -p`, scoped to `clickhousectl`) that investigates the live system and applies the right scaling action — horizontal or vertical — on its own.

Includes README, `schema.sql`, `config.env.example`, and scripts for traffic (`frontend.sh`), load (`load.sh`), watching (`watch.sh`), and handoff (`investigate.sh`).

Also adds a `.gitignore` so `config.env` (real credentials) stays untracked, and restores root README entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)