### PR TITLE
Refresh core Compose recipes and add lightweight validation

### DIFF
--- a/docker-compose-recipes/README.md
+++ b/docker-compose-recipes/README.md
@@ -1,6 +1,10 @@
 # ClickHouse Docker Compose recipes
 
-A list of ClickHouse docker compose recipes
+Small local examples for learning ClickHouse topologies and integrations. These
+are development environments with public example credentials and no production
+security, backup or availability guarantees. Run one recipe at a time: several
+use the same host ports. Refreshed core recipes bind host ports to loopback;
+check older integrations before starting them on a shared machine.
 
 - [ClickHouse single node with Keeper](./recipes/ch-1S_1K/README.md)
 - [ClickHouse single node with Keeper and IMDB dataset](./recipes/ch-1S_1K_IMDB_dataset/README.md)
@@ -19,112 +23,62 @@ A list of ClickHouse docker compose recipes
 - [ClickHouse and LDAP (OpenLDAP)](./recipes/ch-and-openldap/README.md)
 - [ClickHouse and Vector syslog and apache demo data](./recipes/ch-and-vector/README.md)
 
-These recipes are provided "AS-IS" and intended strictly and only for local quick and dirty testing.
+## Start, verify and reset
 
+Install Docker with Compose v2 (`docker compose version`). No host application
+packages are needed. Allow Docker access to your checkout if your desktop runtime
+requires file sharing. Budget at least 2 CPUs and 4 GiB RAM for a small recipe;
+clusters need more, as described in their READMEs.
 
+From the repository root, for example:
 
-## How to use
-
-Each recipe runs as a pre-configured docker compose setup.
-
-- clone this repository locally (`cd /opt && git clone https://github.com/ClickHouse/examples`)
-- make sure the path _where_ you clone this repo (in this _example_ `/opt`) is added to your docker sharing settings
-![](./extras/add_path_to_docker_settings.png)
-- `cd` into the desire recipe directory (e.g. `cd recipes/ch-and-grafana`)
-- run `docker compose up` to launch the recipe
-- ctrl+C will abort execution
-- once done, run `docker compose down` to tear down the environment
-
-## Resources
-
-Make sure enough cpu cores, memory and disk are allocated for docker containers through docker settings.
-Some of these recipes do use up to 8 different containers.
-
-## Configuration files
-
-The configuration files for ClickHouse server, ClickHouse Keeper, and all of the other components that
-are deployed by the recipes are located in the `fs/volumes/` subdirectory of each recipe.  For example,
-to learn how ClickHouse Keeper is configured for the `cluster_1S_2R` recipe, you would look at [keeper_config.xml](./recipes/cluster_1S_2R/fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml) and the similar files for the other two Keeper servers.
-
-## Connecting to ClickHouse
-
-All recipes have the `default` user configured with no password and full privileges.
-
-If you have `clickhouse client` on your workstation you can generally run `clickhouse client` and connect to the Docker ClickHouse instance.
-
-If running a recipe with multiple ClickHouse ([example](https://github.com/ClickHouse/examples/tree/main/docker-compose-recipes/recipes/cluster_2S_1R)), while the first instance normally binds to your localhost as the default ClickHouse native protocol port [9000](https://github.com/ClickHouse/examples//blob/93291fe2ca143d7d0ec1ec02ad61f50dc2f83788/docker-compose-recipes/recipes/cluster_2S_2R/docker-compose.yaml#L13-L14) normally, however other instances will use a different port to bind the ClickHouse native TCP connection to your localhost ([example](https://github.com/ClickHouse/examples/blob/93291fe2ca143d7d0ec1ec02ad61f50dc2f83788/docker-compose-recipes/recipes/cluster_2S_2R/docker-compose.yaml#L28) where `clickhouse-02` binds on localhost port `9001`), in this case you will want to specify:
-
-`clickhouse client --port 9001`
-
-
-You may want to run `clickhouse client` within one of more of the containers so that the version of the client matches the version
-of the server.  You can run a command like this:
-
-```bash
-docker compose exec clickhouse-01 clickhouse-client
+```sh
+cd docker-compose-recipes/recipes/ch-1S_1K
+docker compose up -d
 ```
 
-Or, to open a shell on the server you can run the following and then look around or run `clickhouse client` from the shell:
+Refreshed recipes include bounded verification commands, fixture assertions and
+the actual ClickHouse version from their manual run. Follow the selected README;
+older integrations are being refreshed independently.
+To inspect a failure, use `docker compose ps` and `docker compose logs --tail=100`.
+To stop and reset a recipe:
 
-```bash
-docker compose exec clickhouse-01 bash
+```sh
+docker compose down -v --remove-orphans
 ```
 
-## Example use
+`down -v` deletes that project's volumes and their data. It does not delete any
+host bind-mounted data; follow the recipe's instructions for those paths.
 
-To test ClickHouse with S3 functionalities, launch the [ClickHouse and MinIO S3](./recipes/ch-and-minio-S3/README.md) recipe:
+ClickHouse defaults to `CHVER=latest`; Keeper defaults to `CHKVER=latest-alpine`.
+To try a particular release, set `CHVER` and `CHKVER` before starting the recipe.
+Manual verification records a date, platform and actual version; floating defaults
+can change after that date. Third-party images may use a tested stable tag.
 
+Configuration lives in each recipe's `fs/volumes/` directory. Existing cluster
+paths are used by [ClickHouse's replication documentation](https://clickhouse.com/docs/architecture/replication).
+The XML element is named `zookeeper` even when its servers are ClickHouse Keeper.
+Coordinate changes to those documented cluster configurations with documentation
+owners before merging.
+
+## Lightweight validation
+
+Run from the repository root with existing Python 3 (standard library only) and
+Docker Compose v2; no package installation or running containers are needed:
+
+```sh
+python3 docker-compose-recipes/scripts/validate.py
 ```
-➜ ch-and-minio-S3$ docker compose up
-[+] Running 4/2
- ⠿ Network ch-and-minio-s3_default            Created                                                                                                                                                                                         0.0s
- ⠿ Container minio                            Created                                                                                                                                                                                         0.0s
- ⠿ Container clickhouse                       Created                                                                                                                                                                                         0.0s
- ⠿ Container ch-and-minio-s3-createbuckets-1  Created                                                                                                                                                                                         0.0s
-Attaching to ch-and-minio-s3-createbuckets-1, clickhouse, minio
-minio                            | Formatting 1st pool, 1 set(s), 1 drives per set.
-minio                            | WARNING: Host local has more than 0 drives of set. A host failure will result in data becoming unavailable.
-minio                            | MinIO Object Storage Server
-minio                            | Copyright: 2015-2023 MinIO, Inc.
-minio                            | License: GNU AGPLv3 <https://www.gnu.org/licenses/agpl-3.0.html>
-minio                            | Version: RELEASE.2023-03-24T21-41-23Z (go1.19.7 linux/arm64)
-minio                            |
-minio                            | Status:         1 Online, 0 Offline.
-minio                            | API: http://0.0.0.0:10000
-minio                            | Console: http://0.0.0.0:10001
-minio                            |
-minio                            | Documentation: https://min.io/docs/minio/linux/index.html
-minio                            | Warning: The standard parity is set to 0. This can lead to data loss.
-ch-and-minio-s3-createbuckets-1  | Added `myminio` successfully.
-ch-and-minio-s3-createbuckets-1  | ●  minio:10000
-ch-and-minio-s3-createbuckets-1  |    Uptime: 1 second
-ch-and-minio-s3-createbuckets-1  |    Version: 2023-03-24T21:41:23Z
-ch-and-minio-s3-createbuckets-1  |    Network: 1/1 OK
-ch-and-minio-s3-createbuckets-1  |    Drives: 1/1 OK
-ch-and-minio-s3-createbuckets-1  |    Pool: 1
-ch-and-minio-s3-createbuckets-1  |
-ch-and-minio-s3-createbuckets-1  | Pools:
-ch-and-minio-s3-createbuckets-1  |    1st, Erasure sets: 1, Drives per erasure set: 1
-ch-and-minio-s3-createbuckets-1  |
-ch-and-minio-s3-createbuckets-1  | 1 drive online, 0 drives offline
-ch-and-minio-s3-createbuckets-1  | Bucket created successfully `myminio/clickhouse`.
-ch-and-minio-s3-createbuckets-1  | mc: Please use 'mc anonymous'
-ch-and-minio-s3-createbuckets-1 exited with code 0
-clickhouse                       | Processing configuration file '/etc/clickhouse-server/config.xml'.
-clickhouse                       | Merging configuration file '/etc/clickhouse-server/config.d/config.xml'.
-clickhouse                       | Merging configuration file '/etc/clickhouse-server/config.d/docker_related_config.xml'.
-clickhouse                       | Logging debug to /var/log/clickhouse-server/clickhouse-server.log
-clickhouse                       | Logging errors to /var/log/clickhouse-server/clickhouse-server.err.log
-minio                            |
-minio                            |  You are running an older version of MinIO released 1 week ago
-minio                            |  Update: Run `mc admin update`
-minio                            |
-minio                            |
-clickhouse                       | Processing configuration file '/etc/clickhouse-server/config.xml'.
-clickhouse                       | Merging configuration file '/etc/clickhouse-server/config.d/config.xml'.
-clickhouse                       | Merging configuration file '/etc/clickhouse-server/config.d/docker_related_config.xml'.
-clickhouse                       | Saved preprocessed configuration to '/var/lib/clickhouse/preprocessed_configs/config.xml'.
-clickhouse                       | Processing configuration file '/etc/clickhouse-server/users.xml'.
-clickhouse                       | Merging configuration file '/etc/clickhouse-server/users.d/users.xml'.
-clickhouse                       | Saved preprocessed configuration to '/var/lib/clickhouse/preprocessed_configs/users.xml'.
-```
+
+This checks local index links, a README for every recipe, Compose configuration,
+and XML syntax. It does not start services or prove integration compatibility.
+When changing a recipe, run its documented happy path once from empty volumes and
+include commands, results, date, platform and versions in the PR. There is no
+scheduled test suite or version matrix.
+
+## ClickHouse Cloud
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages ClickHouse infrastructure.
+[ClickPipes](https://clickhouse.com/cloud/clickpipes) provides managed ingestion for
+supported sources. Each refreshed recipe explains the applicable Cloud path;
+Keeper and proxy topology internals are self-managed lessons.

--- a/docker-compose-recipes/recipes/ch-1S_1K/README.md
+++ b/docker-compose-recipes/recipes/ch-1S_1K/README.md
@@ -1,13 +1,69 @@
-# ClickHouse ch-1S_1K
+# ClickHouse with one Keeper
 
-Single node ClickHouse instance leveraging 1 ClickHouse Keeper
+A single ClickHouse server and one Keeper demonstrate coordinated table metadata with a tiny replicated table. This does not teach production availability, TLS, or backups.
 
-By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
-will be `latest-alpine`.  You can specify specific versions by setting environment
-variables before running `docker compose up`.
+These are local teaching configurations, not production deployments. Published ports bind to `127.0.0.1`, but the default ClickHouse user has no password and containers on the recipe network can connect. Do not expose these ports or reuse the example credentials on a shared host.
+
+## Prerequisites
+
+Use Docker Engine/Desktop or OrbStack with Docker Compose v2, Bash, and curl. Allocate roughly 4 GiB of Docker memory and 2 CPUs, with several GiB of free disk for images and logs. ClickHouse and Keeper images support Linux amd64 and arm64; use a Docker Linux VM on macOS/Windows. Run one recipe at a time: the fixed container names and host ports overlap across examples.
+
+ClickHouse defaults to `CHVER=latest` and Keeper to `CHKVER=latest-alpine`. To select other images, export `CHVER` and `CHKVER` before starting; these overrides are intentionally retained. The verification prints the actual server version. Floating tags are not a compatibility guarantee.
+
+Last manually verified: **2026-09-06**, ClickHouse **26.8.2.7**, Keeper **26.8.2.7**, Linux **aarch64** on OrbStack (Docker 29.4.0 / Compose 5.1.2). The complete happy path below passed from empty volumes; this is a single-platform manual check.
+
+## Start and verify
+
+From this recipe directory, run the following Bash block. It polls each server's Keeper connection at most 30 times (each request is limited to 10 seconds); subsequent SQL requests are limited to 60 seconds. If it fails, inspect `docker compose logs --tail=100`.
 
 ```bash
-export CHVER=23.4
-export CHKVER=23.4-alpine
-docker compose up
+set -eu
+docker compose up -d
+for port in 8123; do
+  ready=false
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 10 "http://127.0.0.1:$port/" \
+      --data-binary "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$ready" != true ]; then
+    echo "ClickHouse/Keeper not ready on port $port" >&2
+    exit 1
+  fi
+done
+q() {
+  curl --fail --silent --show-error --max-time 60 \
+    'http://127.0.0.1:8123/?distributed_ddl_task_timeout=60' --data-binary "$1"
+}
+q 'SELECT version()'
+q "CREATE TABLE demo (id UInt32, message String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/demo', 'replica-1') ORDER BY id"
+q "INSERT INTO demo VALUES (1, 'hello keeper')"
+[ "$(q 'SELECT count() FROM demo')" = 1 ]
+[ "$(q 'SELECT message FROM demo WHERE id = 1')" = 'hello keeper' ]
+q 'SELECT * FROM demo'
+echo 'OK: one row in a Keeper-coordinated table'
 ```
+
+Expected output includes the actual ClickHouse version, `1 / hello keeper`, and the final `OK` line. Keeper coordinates the table metadata; one server and one Keeper do not provide redundancy.
+
+## Stop, rerun, and reset
+
+`docker compose stop` preserves the existing containers for `docker compose start`. Before repeating the creation/insertion walkthrough, reset to empty state:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+This is destructive: it removes recipe containers and their anonymous data volumes, including all inserted data and Keeper state. The checked-in configuration and fixture remain. Then repeat the start/verify block. These examples are disposable and do not configure durable host data directories.
+
+## ClickHouse Cloud and documentation
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages the service's replication and scaling. Keeper wiring, explicit shard layouts, and CHProxy are self-managed infrastructure lessons; do not copy this Compose topology into Cloud.
+
+- [ClickHouse architecture](https://clickhouse.com/docs/architecture/introduction)
+- [ReplicatedMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication)
+- [Distributed tables](https://clickhouse.com/docs/engines/table-engines/special/distributed)
+- [ClickHouse Keeper](https://clickhouse.com/docs/guides/sre/keeper)

--- a/docker-compose-recipes/recipes/ch-1S_1K/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/ch-1S_1K/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clickhouse:
     image: 'clickhouse/clickhouse-server:${CHVER:-latest}'
@@ -6,8 +5,8 @@ services:
     container_name: clickhouse
     hostname: clickhouse
     volumes:
-      - ${PWD}/fs/volumes/clickhouse/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - '127.0.0.1:8123:8123'
       - '127.0.0.1:9000:9000'
@@ -19,6 +18,6 @@ services:
     container_name: clickhouse-keeper
     hostname: clickhouse-keeper
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-keeper/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+      - ./fs/volumes/clickhouse-keeper/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
       - '127.0.0.1:9181:9181'

--- a/docker-compose-recipes/recipes/ch-1S_1K_IMDB_dataset/README.md
+++ b/docker-compose-recipes/recipes/ch-1S_1K_IMDB_dataset/README.md
@@ -1,15 +1,77 @@
-# ClickHouse ch-1S_1K_IMDB_dataset
+# ClickHouse with one Keeper and a small IMDb-schema fixture
 
-Single node ClickHouse instance leveraging 1 ClickHouse Keeper with IMDB dataset 
+A single ClickHouse server and one Keeper load a tiny synthetic fixture using the IMDb schema. Six related tables demonstrate joins without downloading the full dataset during startup. This does not teach production availability, TLS, or backups.
 
-By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
-will be `latest-alpine`.  You can specify specific versions by setting environment
-variables before running `docker compose up`.
+These are local teaching configurations, not production deployments. Published ports bind to `127.0.0.1`, but the default ClickHouse user has no password and containers on the recipe network can connect. Do not expose these ports or reuse the example credentials on a shared host.
 
-This recipe simply automates the [IMDB dataset](https://en.wikipedia.org/wiki/IMDb) loading illustrated [here](https://clickhouse.com/docs/en/integrations/dbt#prepare-clickhouse).
+## Prerequisites
+
+Use Docker Engine/Desktop or OrbStack with Docker Compose v2, Bash, and curl. Allocate roughly 4 GiB of Docker memory and 2 CPUs, with several GiB of free disk for images and logs. ClickHouse and Keeper images support Linux amd64 and arm64; use a Docker Linux VM on macOS/Windows. Run one recipe at a time: the fixed container names and host ports overlap across examples.
+
+ClickHouse defaults to `CHVER=latest` and Keeper to `CHKVER=latest-alpine`. To select other images, export `CHVER` and `CHKVER` before starting; these overrides are intentionally retained. The verification prints the actual server version. Floating tags are not a compatibility guarantee.
+
+Last manually verified: **2026-09-06**, ClickHouse **26.8.2.7**, Keeper **26.8.2.7**, Linux **aarch64** on OrbStack (Docker 29.4.0 / Compose 5.1.2). The complete happy path below passed from empty volumes; this is a single-platform manual check.
+
+## Start and verify
+
+From this recipe directory, run the following Bash block. It polls each server's Keeper connection at most 30 times (each request is limited to 10 seconds); subsequent SQL requests are limited to 60 seconds. If it fails, inspect `docker compose logs --tail=100`.
 
 ```bash
-export CHVER=23.4
-export CHKVER=23.4-alpine
-docker compose up
+set -eu
+docker compose up -d
+for port in 8123; do
+  ready=false
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 10 "http://127.0.0.1:$port/" \
+      --data-binary "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$ready" != true ]; then
+    echo "ClickHouse/Keeper not ready on port $port" >&2
+    exit 1
+  fi
+done
+q() {
+  curl --fail --silent --show-error --max-time 60 \
+    'http://127.0.0.1:8123/?distributed_ddl_task_timeout=60' --data-binary "$1"
+}
+q 'SELECT version()'
+# The entrypoint loads the fixture before the final server starts.
+ready=false
+for attempt in {1..30}; do
+  if [ "$(q 'SELECT count() FROM imdb.roles' 2>/dev/null)" = 2 ]; then
+    ready=true
+    break
+  fi
+  sleep 2
+done
+[ "$ready" = true ]
+[ "$(q 'SELECT count() FROM imdb.movies')" = 2 ]
+[ "$(q "SELECT count() FROM imdb.movies m JOIN imdb.movie_directors md ON m.id = md.movie_id JOIN imdb.directors d ON d.id = md.director_id WHERE d.first_name = 'Casey'")" = 2 ]
+q 'SELECT m.name, a.first_name, r.role FROM imdb.movies m JOIN imdb.roles r ON m.id = r.movie_id JOIN imdb.actors a ON a.id = r.actor_id ORDER BY m.id'
+echo 'OK: two movies, two roles, and both director links'
 ```
+
+Expected join output is `Example Movie / Alex / Lead` and `Another Example / Sam / Lead`. These invented rows are for a deterministic quick start, not a sample of actual IMDb records. For a larger, optional exercise, follow the [IMDb/dbt dataset walkthrough](https://clickhouse.com/docs/integrations/dbt); downloading that dataset is not part of startup.
+
+## Stop, rerun, and reset
+
+`docker compose stop` preserves the existing containers for `docker compose start`. Before repeating the creation/insertion walkthrough, reset to empty state:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+This is destructive: it removes recipe containers and their anonymous data volumes, including all inserted data and Keeper state. The checked-in configuration and fixture remain. Then repeat the start/verify block. These examples are disposable and do not configure durable host data directories.
+
+## ClickHouse Cloud and documentation
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages the service's replication and scaling. Keeper wiring, explicit shard layouts, and CHProxy are self-managed infrastructure lessons; do not copy this Compose topology into Cloud.
+
+- [ClickHouse architecture](https://clickhouse.com/docs/architecture/introduction)
+- [ReplicatedMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication)
+- [Distributed tables](https://clickhouse.com/docs/engines/table-engines/special/distributed)
+- [ClickHouse Keeper](https://clickhouse.com/docs/guides/sre/keeper)

--- a/docker-compose-recipes/recipes/ch-1S_1K_IMDB_dataset/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/ch-1S_1K_IMDB_dataset/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clickhouse:
     image: 'clickhouse/clickhouse-server:${CHVER:-latest}'
@@ -6,9 +5,9 @@ services:
     container_name: clickhouse
     hostname: clickhouse
     volumes:
-      - ${PWD}/fs/volumes/clickhouse/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
-      - ${PWD}/fs/volumes/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - ./fs/volumes/clickhouse/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     ports:
       - '127.0.0.1:8123:8123'
       - '127.0.0.1:9000:9000'
@@ -20,6 +19,6 @@ services:
     container_name: clickhouse-keeper
     hostname: clickhouse-keeper
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-keeper/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+      - ./fs/volumes/clickhouse-keeper/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
       - '127.0.0.1:9181:9181'

--- a/docker-compose-recipes/recipes/ch-1S_1K_IMDB_dataset/fs/volumes/clickhouse/docker-entrypoint-initdb.d/07_insert.sh
+++ b/docker-compose-recipes/recipes/ch-1S_1K_IMDB_dataset/fs/volumes/clickhouse/docker-entrypoint-initdb.d/07_insert.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-set -e 
-clickhouse client -n <<-EOSQL
-INSERT INTO imdb.actors SELECT * FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/imdb/imdb_ijs_actors.tsv.gz', 'TSVWithNames');
-INSERT INTO imdb.directors SELECT * FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/imdb/imdb_ijs_directors.tsv.gz', 'TSVWithNames');
-INSERT INTO imdb.genres SELECT * FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/imdb/imdb_ijs_movies_genres.tsv.gz', 'TSVWithNames');
-INSERT INTO imdb.movies SELECT * FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/imdb/imdb_ijs_movies.tsv.gz', 'TSVWithNames');
-INSERT INTO imdb.roles (actor_id, movie_id, role) SELECT actor_id,movie_id,role FROM s3('https://datasets-documentation.s3.eu-west-3.amazonaws.com/imdb/imdb_ijs_roles.tsv.gz', 'TSVWithNames');
+set -euo pipefail
+# Tiny synthetic fixture using the IMDb schema; no startup downloads.
+clickhouse client -n <<'EOSQL'
+INSERT INTO imdb.actors VALUES (1, 'Alex', 'Example', 'X'), (2, 'Sam', 'Sample', 'X');
+INSERT INTO imdb.directors VALUES (1, 'Casey', 'Example');
+INSERT INTO imdb.genres VALUES (1, 'Drama'), (2, 'Comedy');
+INSERT INTO imdb.movies VALUES (1, 'Example Movie', 2024, 7.5), (2, 'Another Example', 2025, 8.0);
+INSERT INTO imdb.movie_directors VALUES (1, 1), (1, 2);
+INSERT INTO imdb.roles (actor_id, movie_id, role) VALUES (1, 1, 'Lead'), (2, 2, 'Lead');
 EOSQL

--- a/docker-compose-recipes/recipes/ch-and-kafka/README.md
+++ b/docker-compose-recipes/recipes/ch-and-kafka/README.md
@@ -1,0 +1,9 @@
+# Legacy Confluent Kafka stack
+
+This unmaintained Compose stack contains a multi-broker Confluent/ZooKeeper
+configuration without a verified produce-to-query walkthrough. It is awaiting
+replacement with a small Kafka-compatible Redpanda example; use the other
+[indexed recipes](../../README.md) for verified local lessons.
+
+For production streaming ingestion, use [ClickPipes](https://clickhouse.com/cloud/clickpipes)
+to connect Kafka or Redpanda to ClickHouse Cloud.

--- a/docker-compose-recipes/recipes/cluster_1S_2R/README.md
+++ b/docker-compose-recipes/recipes/cluster_1S_2R/README.md
@@ -1,19 +1,83 @@
-# ClickHouse cluster cluster_1S_2R
+# ClickHouse: 1 shard, 2 replicas per shard
 
-2 ClickHouse instances leveraging 3 dedicated ClickHouse Keepers
+2 ClickHouse servers and three Keeper nodes demonstrate replication within one shard. This does not teach production availability, TLS, or backups.
 
-1 Shard with replication across clickhouse-01 and clickhouse-02
+These are local teaching configurations, not production deployments. Published ports bind to `127.0.0.1`, but the default ClickHouse user has no password and containers on the recipe network can connect. Do not expose these ports or reuse the example credentials on a shared host.
 
-By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
-will be `latest-alpine`.  You can specify specific versions by setting environment
-variables before running `docker compose up`.
+## Prerequisites
+
+Use Docker Engine/Desktop or OrbStack with Docker Compose v2, Bash, and curl. Allocate roughly 8 GiB of Docker memory and 4 CPUs, with several GiB of free disk for images and logs. ClickHouse and Keeper images support Linux amd64 and arm64; use a Docker Linux VM on macOS/Windows. Run one recipe at a time: the fixed container names and host ports overlap across examples.
+
+ClickHouse defaults to `CHVER=latest` and Keeper to `CHKVER=latest-alpine`. To select other images, export `CHVER` and `CHKVER` before starting; these overrides are intentionally retained. The verification prints the actual server version. Floating tags are not a compatibility guarantee.
+
+Last manually verified: **2026-09-06**, ClickHouse **26.8.2.7**, Keeper **26.8.2.7**, Linux **aarch64** on OrbStack (Docker 29.4.0 / Compose 5.1.2). The complete happy path below passed from empty volumes; this is a single-platform manual check.
+
+## Start and verify
+
+From this recipe directory, run the following Bash block. It polls each server's Keeper connection at most 30 times (each request is limited to 10 seconds); subsequent SQL requests are limited to 60 seconds. If it fails, inspect `docker compose logs --tail=100`.
 
 ```bash
-export CHVER=23.4
-export CHKVER=23.4-alpine
-docker compose up
+set -eu
+docker compose up -d
+for port in 8123 8124; do
+  ready=false
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 10 "http://127.0.0.1:$port/" \
+      --data-binary "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$ready" != true ]; then
+    echo "ClickHouse/Keeper not ready on port $port" >&2
+    exit 1
+  fi
+done
+q() {
+  curl --fail --silent --show-error --max-time 60 \
+    'http://127.0.0.1:8123/?distributed_ddl_task_timeout=60' --data-binary "$1"
+}
+q 'SELECT version()'
+q 'CREATE DATABASE recipe ON CLUSTER cluster_1S_2R'
+q "CREATE TABLE recipe.events_local ON CLUSTER cluster_1S_2R (id UInt32, message String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/{uuid}', '{replica}') ORDER BY id"
+q "CREATE TABLE recipe.events ON CLUSTER cluster_1S_2R AS recipe.events_local ENGINE = Distributed('cluster_1S_2R', 'recipe', 'events_local', id)"
+# Foreground insertion waits for delivery to each selected shard.
+q "INSERT INTO recipe.events SETTINGS distributed_foreground_insert = 1 VALUES (0, 'hello'), (1, 'keeper')"
+for port in 8123 8124; do
+  curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/?receive_timeout=45" \
+    --data-binary 'SYSTEM SYNC REPLICA recipe.events_local'
+done
+[ "$(q 'SELECT count() FROM recipe.events')" = 2 ]
+[ "$(q "SELECT message FROM recipe.events WHERE id = 1")" = keeper ]
+# Check each physical node, not only the Distributed table.
+for port in 8123 8124; do
+  count=$(curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/" \
+    --data-binary 'SELECT count() FROM recipe.events_local')
+  [ "$count" = 2 ]
+  echo "port $port: $count local row(s)"
+done
+q 'SELECT * FROM recipe.events ORDER BY id'
+echo 'OK: topology assertions passed'
 ```
 
-This Docker compose file deploys a configuration matching [this
-example in the documentation](https://clickhouse.com/docs/en/architecture/replication).
-See the docs for information on terminology, configuration, and testing.
+Expected output includes the actual ClickHouse version, two rows (`0 / hello`, `1 / keeper`), and 2 local row(s) on every ClickHouse node. Replication is asynchronous, so the walkthrough synchronizes replicas before checking their contents. The final `OK` lines mean the assertions passed.
+
+## Stop, rerun, and reset
+
+`docker compose stop` preserves the existing containers for `docker compose start`. Before repeating the creation/insertion walkthrough, reset to empty state:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+This is destructive: it removes recipe containers and their anonymous data volumes, including all inserted data and Keeper state. The checked-in configuration and fixture remain. Then repeat the start/verify block. These examples are disposable and do not configure durable host data directories.
+
+## ClickHouse Cloud and documentation
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages the service's replication and scaling. Keeper wiring, explicit shard layouts, and CHProxy are self-managed infrastructure lessons; do not copy this Compose topology into Cloud.
+
+- [ClickHouse architecture](https://clickhouse.com/docs/architecture/introduction)
+- [ReplicatedMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication)
+- [Distributed tables](https://clickhouse.com/docs/engines/table-engines/special/distributed)
+- [ClickHouse Keeper](https://clickhouse.com/docs/guides/sre/keeper)

--- a/docker-compose-recipes/recipes/cluster_1S_2R/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_1S_2R/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clickhouse-01:
     image: "clickhouse/clickhouse-server:${CHVER:-latest}"
@@ -6,8 +5,8 @@ services:
     container_name: clickhouse-01
     hostname: clickhouse-01
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9000:9000"
@@ -21,8 +20,8 @@ services:
     container_name: clickhouse-02
     hostname: clickhouse-02
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8124:8123"
       - "127.0.0.1:9001:9000"
@@ -36,7 +35,7 @@ services:
     container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
@@ -45,7 +44,7 @@ services:
     container_name: clickhouse-keeper-02
     hostname: clickhouse-keeper-02
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
@@ -54,6 +53,6 @@ services:
     container_name: clickhouse-keeper-03
     hostname: clickhouse-keeper-03
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9183:9181"

--- a/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/README.md
+++ b/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/README.md
@@ -1,21 +1,88 @@
-# ClickHouse cluster cluster_1S_2R
+# ClickHouse: 1 shard, 2 replicas per shard with CHProxy
 
-2 ClickHouse instances leveraging 3 dedicated ClickHouse Keepers and CH Proxy load balancer
+2 ClickHouse servers and three Keeper nodes demonstrate replication within one shard. CHProxy forwards HTTP queries to the ClickHouse nodes; queries against the Distributed table read the whole cluster. This does not teach production availability, TLS, or backups.
 
-1 Shard with replication across clickhouse-01 and clickhouse-02
+These are local teaching configurations, not production deployments. Published ports bind to `127.0.0.1`, but the default ClickHouse user has no password and containers on the recipe network can connect. Do not expose these ports or reuse the example credentials on a shared host. The proxy user has no password, and port 80 serves plain HTTP.
 
-By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
-will be `latest-alpine`.  You can specify specific versions by setting environment
-variables before running `docker compose up`.
+## Prerequisites
+
+Use Docker Engine/Desktop or OrbStack with Docker Compose v2, Bash, and curl. Allocate roughly 8 GiB of Docker memory and 4 CPUs, with several GiB of free disk for images and logs. ClickHouse and Keeper images support Linux amd64 and arm64; use a Docker Linux VM on macOS/Windows. This recipe retains CHProxy `v1.26.4` on `linux/amd64`; arm64 hosts require amd64 emulation. Its fixed private subnet must not overlap your existing Docker networks. Run one recipe at a time: the fixed container names and host ports overlap across examples.
+
+ClickHouse defaults to `CHVER=latest` and Keeper to `CHKVER=latest-alpine`. To select other images, export `CHVER` and `CHKVER` before starting; these overrides are intentionally retained. The verification prints the actual server version. Floating tags are not a compatibility guarantee.
+
+Last manually verified: **2026-09-06**, ClickHouse **26.8.2.7**, Keeper **26.8.2.7**, Linux **aarch64** on OrbStack (Docker 29.4.0 / Compose 5.1.2). CHProxy **v1.26.4** ran as **linux/amd64 under emulation**. The complete happy path below passed from empty volumes; this is a single-platform manual check.
+
+## Start and verify
+
+From this recipe directory, run the following Bash block. It polls each server's Keeper connection at most 30 times (each request is limited to 10 seconds); subsequent SQL requests are limited to 60 seconds. If it fails, inspect `docker compose logs --tail=100`.
 
 ```bash
-export CHVER=23.4
-export CHKVER=23.4-alpine
-docker compose up
+set -eu
+docker compose up -d
+for port in 8123 8124; do
+  ready=false
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 10 "http://127.0.0.1:$port/" \
+      --data-binary "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$ready" != true ]; then
+    echo "ClickHouse/Keeper not ready on port $port" >&2
+    exit 1
+  fi
+done
+q() {
+  curl --fail --silent --show-error --max-time 60 \
+    'http://127.0.0.1:8123/?distributed_ddl_task_timeout=60' --data-binary "$1"
+}
+q 'SELECT version()'
+q 'CREATE DATABASE recipe ON CLUSTER cluster_1S_2R'
+q "CREATE TABLE recipe.events_local ON CLUSTER cluster_1S_2R (id UInt32, message String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/{uuid}', '{replica}') ORDER BY id"
+q "CREATE TABLE recipe.events ON CLUSTER cluster_1S_2R AS recipe.events_local ENGINE = Distributed('cluster_1S_2R', 'recipe', 'events_local', id)"
+# Foreground insertion waits for delivery to each selected shard.
+q "INSERT INTO recipe.events SETTINGS distributed_foreground_insert = 1 VALUES (0, 'hello'), (1, 'keeper')"
+for port in 8123 8124; do
+  curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/?receive_timeout=45" \
+    --data-binary 'SYSTEM SYNC REPLICA recipe.events_local'
+done
+[ "$(q 'SELECT count() FROM recipe.events')" = 2 ]
+[ "$(q "SELECT message FROM recipe.events WHERE id = 1")" = keeper ]
+# Check each physical node, not only the Distributed table.
+for port in 8123 8124; do
+  count=$(curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/" \
+    --data-binary 'SELECT count() FROM recipe.events_local')
+  [ "$count" = 2 ]
+  echo "port $port: $count local row(s)"
+done
+q 'SELECT * FROM recipe.events ORDER BY id'
+# Query the same Distributed table through the published proxy endpoint.
+[ "$(curl --fail --silent --show-error --max-time 30 --user 'admin_1S_2R:' \
+  http://127.0.0.1:80/ --data-binary 'SELECT count() FROM recipe.events')" = 2 ]
+echo 'OK: query through CHProxy returned two rows'
+echo 'OK: topology assertions passed'
 ```
 
-This Docker compose file deploys a configuration very similar to [this
-example in the documentation](https://clickhouse.com/docs/en/architecture/replication), the main difference is that this adds Chproxy.
-See the docs for information on terminology, configuration, and testing.
+Expected output includes the actual ClickHouse version, two rows (`0 / hello`, `1 / keeper`), and 2 local row(s) on every ClickHouse node. Replication is asynchronous, so the walkthrough synchronizes replicas before checking their contents. The proxy assertion demonstrates query forwarding. This walkthrough does not claim to validate failover under load. The final `OK` lines mean the assertions passed.
 
-See the [Chproxy docs](https://www.chproxy.org/) for information on the proxy. See the [license](https://github.com/ContentSquare/chproxy/blob/master/LICENSE) in the GitHub repo.
+## Stop, rerun, and reset
+
+`docker compose stop` preserves the existing containers for `docker compose start`. Before repeating the creation/insertion walkthrough, reset to empty state:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+This is destructive: it removes recipe containers and their anonymous data volumes, including all inserted data and Keeper state. The checked-in configuration and fixture remain. Then repeat the start/verify block. These examples are disposable and do not configure durable host data directories.
+
+## ClickHouse Cloud and documentation
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages the service's replication and scaling. Keeper wiring, explicit shard layouts, and CHProxy are self-managed infrastructure lessons; do not copy this Compose topology into Cloud.
+
+- [ClickHouse architecture](https://clickhouse.com/docs/architecture/introduction)
+- [ReplicatedMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication)
+- [Distributed tables](https://clickhouse.com/docs/engines/table-engines/special/distributed)
+- [ClickHouse Keeper](https://clickhouse.com/docs/guides/sre/keeper)
+- [CHProxy configuration](https://www.chproxy.org/configuration/)

--- a/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_1S_2R_ch_proxy/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clickhouse-01:
     image: "clickhouse/clickhouse-server:${CHVER:-latest}"
@@ -9,8 +8,8 @@ services:
       cluster_1S_2R_ch_proxy:
         ipv4_address: 192.168.5.1
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9000:9000"
@@ -27,8 +26,8 @@ services:
       cluster_1S_2R_ch_proxy:
         ipv4_address: 192.168.5.2
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8124:8123"
       - "127.0.0.1:9001:9000"
@@ -42,7 +41,7 @@ services:
     container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+      - ./fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     networks:
       cluster_1S_2R_ch_proxy:
         ipv4_address: 192.168.5.5
@@ -54,7 +53,7 @@ services:
     container_name: clickhouse-keeper-02
     hostname: clickhouse-keeper-02
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+      - ./fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     networks:
       cluster_1S_2R_ch_proxy:
         ipv4_address: 192.168.5.6
@@ -66,7 +65,7 @@ services:
     container_name: clickhouse-keeper-03
     hostname: clickhouse-keeper-03
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+      - ./fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     networks:
       cluster_1S_2R_ch_proxy:
         ipv4_address: 192.168.5.7
@@ -81,14 +80,13 @@ services:
       cluster_1S_2R_ch_proxy:
         ipv4_address: 192.168.5.10
     ports:
-      - "127.0.0.1:443:443"
       - "127.0.0.1:80:80"
     volumes:
-      - ${PWD}/fs/volumes/ch-proxy/config/config.yml:/opt/config.yml
+      - ./fs/volumes/ch-proxy/config/config.yml:/opt/config.yml
     depends_on:
       - clickhouse-01
       - clickhouse-02
-    command: [-config, /opt/config.yml]         
+    command: [-config, /opt/config.yml]
 networks:
   cluster_1S_2R_ch_proxy:
     driver: bridge

--- a/docker-compose-recipes/recipes/cluster_2S_1R/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_1R/README.md
@@ -1,19 +1,79 @@
-# ClickHouse cluster cluster_2S_1R
+# ClickHouse: 2 shards, 1 replica per shard
 
-2 ClickHouse instances leveraging 3 dedicated ClickHouse Keepers
+2 ClickHouse servers and three Keeper nodes demonstrate sharding without redundant data replicas. This does not teach production availability, TLS, or backups.
 
-2 Shards with no replication configured
+These are local teaching configurations, not production deployments. Published ports bind to `127.0.0.1`, but the default ClickHouse user has no password and containers on the recipe network can connect. Do not expose these ports or reuse the example credentials on a shared host.
 
-By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
-will be `latest-alpine`.  You can specify specific versions by setting environment
-variables before running `docker compose up`.
+## Prerequisites
+
+Use Docker Engine/Desktop or OrbStack with Docker Compose v2, Bash, and curl. Allocate roughly 8 GiB of Docker memory and 4 CPUs, with several GiB of free disk for images and logs. ClickHouse and Keeper images support Linux amd64 and arm64; use a Docker Linux VM on macOS/Windows. Run one recipe at a time: the fixed container names and host ports overlap across examples.
+
+ClickHouse defaults to `CHVER=latest` and Keeper to `CHKVER=latest-alpine`. To select other images, export `CHVER` and `CHKVER` before starting; these overrides are intentionally retained. The verification prints the actual server version. Floating tags are not a compatibility guarantee.
+
+Last manually verified: **2026-09-06**, ClickHouse **26.8.2.7**, Keeper **26.8.2.7**, Linux **aarch64** on OrbStack (Docker 29.4.0 / Compose 5.1.2). The complete happy path below passed from empty volumes; this is a single-platform manual check.
+
+## Start and verify
+
+From this recipe directory, run the following Bash block. It polls each server's Keeper connection at most 30 times (each request is limited to 10 seconds); subsequent SQL requests are limited to 60 seconds. If it fails, inspect `docker compose logs --tail=100`.
 
 ```bash
-export CHVER=23.4
-export CHKVER=23.4-alpine
-docker compose up
+set -eu
+docker compose up -d
+for port in 8123 8124; do
+  ready=false
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 10 "http://127.0.0.1:$port/" \
+      --data-binary "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$ready" != true ]; then
+    echo "ClickHouse/Keeper not ready on port $port" >&2
+    exit 1
+  fi
+done
+q() {
+  curl --fail --silent --show-error --max-time 60 \
+    'http://127.0.0.1:8123/?distributed_ddl_task_timeout=60' --data-binary "$1"
+}
+q 'SELECT version()'
+q 'CREATE DATABASE recipe ON CLUSTER cluster_2S_1R'
+q "CREATE TABLE recipe.events_local ON CLUSTER cluster_2S_1R (id UInt32, message String) ENGINE = MergeTree ORDER BY id"
+q "CREATE TABLE recipe.events ON CLUSTER cluster_2S_1R AS recipe.events_local ENGINE = Distributed('cluster_2S_1R', 'recipe', 'events_local', id)"
+# Foreground insertion waits for delivery to each selected shard.
+q "INSERT INTO recipe.events SETTINGS distributed_foreground_insert = 1 VALUES (0, 'hello'), (1, 'keeper')"
+[ "$(q 'SELECT count() FROM recipe.events')" = 2 ]
+[ "$(q "SELECT message FROM recipe.events WHERE id = 1")" = keeper ]
+# Check each physical node, not only the Distributed table.
+for port in 8123 8124; do
+  count=$(curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/" \
+    --data-binary 'SELECT count() FROM recipe.events_local')
+  [ "$count" = 1 ]
+  echo "port $port: $count local row(s)"
+done
+q 'SELECT * FROM recipe.events ORDER BY id'
+echo 'OK: topology assertions passed'
 ```
 
-This Docker compose file deploys a configuration similar to [this
-example in the documentation](https://clickhouse.com/docs/en/architecture/horizontal-scaling) with the main difference being that 3 independent ClickHouse keeper instances are used in this recipe (instead of just one as in the docs).
-See the docs for information on terminology, configuration, and testing.
+Expected output includes the actual ClickHouse version, two rows (`0 / hello`, `1 / keeper`), and 1 local row(s) on every ClickHouse node. The final `OK` lines mean the assertions passed.
+
+## Stop, rerun, and reset
+
+`docker compose stop` preserves the existing containers for `docker compose start`. Before repeating the creation/insertion walkthrough, reset to empty state:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+This is destructive: it removes recipe containers and their anonymous data volumes, including all inserted data and Keeper state. The checked-in configuration and fixture remain. Then repeat the start/verify block. These examples are disposable and do not configure durable host data directories.
+
+## ClickHouse Cloud and documentation
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages the service's replication and scaling. Keeper wiring, explicit shard layouts, and CHProxy are self-managed infrastructure lessons; do not copy this Compose topology into Cloud.
+
+- [ClickHouse architecture](https://clickhouse.com/docs/architecture/introduction)
+- [ReplicatedMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication)
+- [Distributed tables](https://clickhouse.com/docs/engines/table-engines/special/distributed)
+- [ClickHouse Keeper](https://clickhouse.com/docs/guides/sre/keeper)

--- a/docker-compose-recipes/recipes/cluster_2S_1R/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_2S_1R/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clickhouse-01:
     image: "clickhouse/clickhouse-server:${CHVER:-latest}"
@@ -9,8 +8,8 @@ services:
       cluster_2S_1R:
         ipv4_address: 192.168.7.1
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9000:9000"
@@ -27,8 +26,8 @@ services:
       cluster_2S_1R:
         ipv4_address: 192.168.7.2
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8124:8123"
       - "127.0.0.1:9001:9000"
@@ -45,7 +44,7 @@ services:
       cluster_2S_1R:
         ipv4_address: 192.168.7.5
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
@@ -57,7 +56,7 @@ services:
       cluster_2S_1R:
         ipv4_address: 192.168.7.6
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
@@ -69,7 +68,7 @@ services:
       cluster_2S_1R:
         ipv4_address: 192.168.7.7
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9183:9181"
 networks:

--- a/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/README.md
@@ -1,21 +1,84 @@
-# ClickHouse cluster cluster_2S_1R
+# ClickHouse: 2 shards, 1 replica per shard with CHProxy
 
-2 ClickHouse instances leveraging 3 dedicated ClickHouse Keepers and CH Proxy load balancer
+2 ClickHouse servers and three Keeper nodes demonstrate sharding without redundant data replicas. CHProxy forwards HTTP queries to the ClickHouse nodes; queries against the Distributed table read the whole cluster. This does not teach production availability, TLS, or backups.
 
-2 Shards with no replication configured
+These are local teaching configurations, not production deployments. Published ports bind to `127.0.0.1`, but the default ClickHouse user has no password and containers on the recipe network can connect. Do not expose these ports or reuse the example credentials on a shared host. The proxy user has no password, and port 80 serves plain HTTP.
 
-By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
-will be `latest-alpine`.  You can specify specific versions by setting environment
-variables before running `docker compose up`.
+## Prerequisites
+
+Use Docker Engine/Desktop or OrbStack with Docker Compose v2, Bash, and curl. Allocate roughly 8 GiB of Docker memory and 4 CPUs, with several GiB of free disk for images and logs. ClickHouse and Keeper images support Linux amd64 and arm64; use a Docker Linux VM on macOS/Windows. This recipe retains CHProxy `v1.26.4` on `linux/amd64`; arm64 hosts require amd64 emulation. Its fixed private subnet must not overlap your existing Docker networks. Run one recipe at a time: the fixed container names and host ports overlap across examples.
+
+ClickHouse defaults to `CHVER=latest` and Keeper to `CHKVER=latest-alpine`. To select other images, export `CHVER` and `CHKVER` before starting; these overrides are intentionally retained. The verification prints the actual server version. Floating tags are not a compatibility guarantee.
+
+Last manually verified: **2026-09-06**, ClickHouse **26.8.2.7**, Keeper **26.8.2.7**, Linux **aarch64** on OrbStack (Docker 29.4.0 / Compose 5.1.2). CHProxy **v1.26.4** ran as **linux/amd64 under emulation**. The complete happy path below passed from empty volumes; this is a single-platform manual check.
+
+## Start and verify
+
+From this recipe directory, run the following Bash block. It polls each server's Keeper connection at most 30 times (each request is limited to 10 seconds); subsequent SQL requests are limited to 60 seconds. If it fails, inspect `docker compose logs --tail=100`.
 
 ```bash
-export CHVER=23.4
-export CHKVER=23.4-alpine
-docker compose up
+set -eu
+docker compose up -d
+for port in 8123 8124; do
+  ready=false
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 10 "http://127.0.0.1:$port/" \
+      --data-binary "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$ready" != true ]; then
+    echo "ClickHouse/Keeper not ready on port $port" >&2
+    exit 1
+  fi
+done
+q() {
+  curl --fail --silent --show-error --max-time 60 \
+    'http://127.0.0.1:8123/?distributed_ddl_task_timeout=60' --data-binary "$1"
+}
+q 'SELECT version()'
+q 'CREATE DATABASE recipe ON CLUSTER cluster_2S_1R'
+q "CREATE TABLE recipe.events_local ON CLUSTER cluster_2S_1R (id UInt32, message String) ENGINE = MergeTree ORDER BY id"
+q "CREATE TABLE recipe.events ON CLUSTER cluster_2S_1R AS recipe.events_local ENGINE = Distributed('cluster_2S_1R', 'recipe', 'events_local', id)"
+# Foreground insertion waits for delivery to each selected shard.
+q "INSERT INTO recipe.events SETTINGS distributed_foreground_insert = 1 VALUES (0, 'hello'), (1, 'keeper')"
+[ "$(q 'SELECT count() FROM recipe.events')" = 2 ]
+[ "$(q "SELECT message FROM recipe.events WHERE id = 1")" = keeper ]
+# Check each physical node, not only the Distributed table.
+for port in 8123 8124; do
+  count=$(curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/" \
+    --data-binary 'SELECT count() FROM recipe.events_local')
+  [ "$count" = 1 ]
+  echo "port $port: $count local row(s)"
+done
+q 'SELECT * FROM recipe.events ORDER BY id'
+# Query the same Distributed table through the published proxy endpoint.
+[ "$(curl --fail --silent --show-error --max-time 30 --user 'admin_2S_1R:' \
+  http://127.0.0.1:80/ --data-binary 'SELECT count() FROM recipe.events')" = 2 ]
+echo 'OK: query through CHProxy returned two rows'
+echo 'OK: topology assertions passed'
 ```
 
-This Docker compose file deploys a configuration similar to [this
-example in the documentation](https://clickhouse.com/docs/en/architecture/horizontal-scaling) with the main difference being that 3 independent ClickHouse keeper instances are used in this recipe (instead of just one as in the docs).
-See the docs for information on terminology, configuration, and testing.
+Expected output includes the actual ClickHouse version, two rows (`0 / hello`, `1 / keeper`), and 1 local row(s) on every ClickHouse node. The proxy assertion demonstrates query forwarding. This walkthrough does not claim to validate failover under load. The final `OK` lines mean the assertions passed.
 
-See the [Chproxy docs](https://www.chproxy.org/) for information on the proxy. See the [license](https://github.com/ContentSquare/chproxy/blob/master/LICENSE) in the GitHub repo.
+## Stop, rerun, and reset
+
+`docker compose stop` preserves the existing containers for `docker compose start`. Before repeating the creation/insertion walkthrough, reset to empty state:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+This is destructive: it removes recipe containers and their anonymous data volumes, including all inserted data and Keeper state. The checked-in configuration and fixture remain. Then repeat the start/verify block. These examples are disposable and do not configure durable host data directories.
+
+## ClickHouse Cloud and documentation
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages the service's replication and scaling. Keeper wiring, explicit shard layouts, and CHProxy are self-managed infrastructure lessons; do not copy this Compose topology into Cloud.
+
+- [ClickHouse architecture](https://clickhouse.com/docs/architecture/introduction)
+- [ReplicatedMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication)
+- [Distributed tables](https://clickhouse.com/docs/engines/table-engines/special/distributed)
+- [ClickHouse Keeper](https://clickhouse.com/docs/guides/sre/keeper)
+- [CHProxy configuration](https://www.chproxy.org/configuration/)

--- a/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_2S_1R_ch_proxy/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clickhouse-01:
     image: "clickhouse/clickhouse-server:${CHVER:-latest}"
@@ -9,8 +8,8 @@ services:
       cluster_2S_1R_ch_proxy:
         ipv4_address: 192.168.7.1
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9000:9000"
@@ -27,8 +26,8 @@ services:
       cluster_2S_1R_ch_proxy:
         ipv4_address: 192.168.7.2
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8124:8123"
       - "127.0.0.1:9001:9000"
@@ -45,7 +44,7 @@ services:
       cluster_2S_1R_ch_proxy:
         ipv4_address: 192.168.7.5
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
@@ -57,7 +56,7 @@ services:
       cluster_2S_1R_ch_proxy:
         ipv4_address: 192.168.7.6
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
@@ -69,7 +68,7 @@ services:
       cluster_2S_1R_ch_proxy:
         ipv4_address: 192.168.7.7
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9183:9181"
   ch-proxy:
@@ -81,10 +80,9 @@ services:
       cluster_2S_1R_ch_proxy:
         ipv4_address: 192.168.7.10
     ports:
-      - "127.0.0.1:443:443"
       - "127.0.0.1:80:80"
     volumes:
-      - ${PWD}/fs/volumes/ch-proxy/config/config.yml:/opt/config.yml
+      - ./fs/volumes/ch-proxy/config/config.yml:/opt/config.yml
     depends_on:
       - clickhouse-01
       - clickhouse-02

--- a/docker-compose-recipes/recipes/cluster_2S_2R/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_2R/README.md
@@ -1,21 +1,83 @@
-# ClickHouse cluster cluster_2S_2R
+# ClickHouse: 2 shards, 2 replicas per shard
 
-4 ClickHouse instances leveraging 3 dedicated ClickHouse Keepers
+4 ClickHouse servers and three Keeper nodes demonstrate sharding and replication. This does not teach production availability, TLS, or backups.
 
-2 Shards with replication:
-- across clickhouse-01 and clickhouse-03 for shard 01
-- across clickhouse-02 and clickhouse-04 for shard 02
+These are local teaching configurations, not production deployments. Published ports bind to `127.0.0.1`, but the default ClickHouse user has no password and containers on the recipe network can connect. Do not expose these ports or reuse the example credentials on a shared host.
 
-By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
-will be `latest-alpine`.  You can specify specific versions by setting environment
-variables before running `docker compose up`.
+## Prerequisites
+
+Use Docker Engine/Desktop or OrbStack with Docker Compose v2, Bash, and curl. Allocate roughly 12 GiB of Docker memory and 4 CPUs, with several GiB of free disk for images and logs. ClickHouse and Keeper images support Linux amd64 and arm64; use a Docker Linux VM on macOS/Windows. Run one recipe at a time: the fixed container names and host ports overlap across examples.
+
+ClickHouse defaults to `CHVER=latest` and Keeper to `CHKVER=latest-alpine`. To select other images, export `CHVER` and `CHKVER` before starting; these overrides are intentionally retained. The verification prints the actual server version. Floating tags are not a compatibility guarantee.
+
+Last manually verified: **2026-09-06**, ClickHouse **26.8.2.7**, Keeper **26.8.2.7**, Linux **aarch64** on OrbStack (Docker 29.4.0 / Compose 5.1.2). The complete happy path below passed from empty volumes; this is a single-platform manual check.
+
+## Start and verify
+
+From this recipe directory, run the following Bash block. It polls each server's Keeper connection at most 30 times (each request is limited to 10 seconds); subsequent SQL requests are limited to 60 seconds. If it fails, inspect `docker compose logs --tail=100`.
 
 ```bash
-export CHVER=23.4
-export CHKVER=23.4-alpine
-docker compose up
+set -eu
+docker compose up -d
+for port in 8123 8124 8125 8126; do
+  ready=false
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 10 "http://127.0.0.1:$port/" \
+      --data-binary "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$ready" != true ]; then
+    echo "ClickHouse/Keeper not ready on port $port" >&2
+    exit 1
+  fi
+done
+q() {
+  curl --fail --silent --show-error --max-time 60 \
+    'http://127.0.0.1:8123/?distributed_ddl_task_timeout=60' --data-binary "$1"
+}
+q 'SELECT version()'
+q 'CREATE DATABASE recipe ON CLUSTER cluster_2S_2R'
+q "CREATE TABLE recipe.events_local ON CLUSTER cluster_2S_2R (id UInt32, message String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/{uuid}', '{replica}') ORDER BY id"
+q "CREATE TABLE recipe.events ON CLUSTER cluster_2S_2R AS recipe.events_local ENGINE = Distributed('cluster_2S_2R', 'recipe', 'events_local', id)"
+# Foreground insertion waits for delivery to each selected shard.
+q "INSERT INTO recipe.events SETTINGS distributed_foreground_insert = 1 VALUES (0, 'hello'), (1, 'keeper')"
+for port in 8123 8124 8125 8126; do
+  curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/?receive_timeout=45" \
+    --data-binary 'SYSTEM SYNC REPLICA recipe.events_local'
+done
+[ "$(q 'SELECT count() FROM recipe.events')" = 2 ]
+[ "$(q "SELECT message FROM recipe.events WHERE id = 1")" = keeper ]
+# Check each physical node, not only the Distributed table.
+for port in 8123 8124 8125 8126; do
+  count=$(curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/" \
+    --data-binary 'SELECT count() FROM recipe.events_local')
+  [ "$count" = 1 ]
+  echo "port $port: $count local row(s)"
+done
+q 'SELECT * FROM recipe.events ORDER BY id'
+echo 'OK: topology assertions passed'
 ```
 
-This Docker compose file deploys a configuration very similar to [these two
-examples in the documentation](https://clickhouse.com/docs/en/architecture/introduction).
-See the docs for information on terminology, configuration, and testing.
+Expected output includes the actual ClickHouse version, two rows (`0 / hello`, `1 / keeper`), and 1 local row(s) on every ClickHouse node. Shard 1 is on clickhouse-01 and clickhouse-03; shard 2 is on clickhouse-02 and clickhouse-04. Replication is asynchronous, so the walkthrough synchronizes replicas before checking their contents. The final `OK` lines mean the assertions passed.
+
+## Stop, rerun, and reset
+
+`docker compose stop` preserves the existing containers for `docker compose start`. Before repeating the creation/insertion walkthrough, reset to empty state:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+This is destructive: it removes recipe containers and their anonymous data volumes, including all inserted data and Keeper state. The checked-in configuration and fixture remain. Then repeat the start/verify block. These examples are disposable and do not configure durable host data directories.
+
+## ClickHouse Cloud and documentation
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages the service's replication and scaling. Keeper wiring, explicit shard layouts, and CHProxy are self-managed infrastructure lessons; do not copy this Compose topology into Cloud.
+
+- [ClickHouse architecture](https://clickhouse.com/docs/architecture/introduction)
+- [ReplicatedMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication)
+- [Distributed tables](https://clickhouse.com/docs/engines/table-engines/special/distributed)
+- [ClickHouse Keeper](https://clickhouse.com/docs/guides/sre/keeper)

--- a/docker-compose-recipes/recipes/cluster_2S_2R/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clickhouse-01:
     image: "clickhouse/clickhouse-server:${CHVER:-latest}"
@@ -6,8 +5,8 @@ services:
     container_name: clickhouse-01
     hostname: clickhouse-01
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9000:9000"
@@ -21,8 +20,8 @@ services:
     container_name: clickhouse-02
     hostname: clickhouse-02
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8124:8123"
       - "127.0.0.1:9001:9000"
@@ -36,8 +35,8 @@ services:
     container_name: clickhouse-03
     hostname: clickhouse-03
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-03/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-03/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8125:8123"
       - "127.0.0.1:9002:9000"
@@ -51,8 +50,8 @@ services:
     container_name: clickhouse-04
     hostname: clickhouse-04
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-04/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-04/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
         - "127.0.0.1:8126:8123"
         - "127.0.0.1:9003:9000"
@@ -66,7 +65,7 @@ services:
     container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
@@ -75,7 +74,7 @@ services:
     container_name: clickhouse-keeper-02
     hostname: clickhouse-keeper-02
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
@@ -84,6 +83,6 @@ services:
     container_name: clickhouse-keeper-03
     hostname: clickhouse-keeper-03
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9183:9181"

--- a/docker-compose-recipes/recipes/cluster_2S_2R_auth/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_auth/README.md
@@ -1,27 +1,92 @@
-# ClickHouse cluster cluster_2S_2R_auth with inter node authentication
+# ClickHouse: 2 shards, 2 replicas per shard with inter-node authentication
 
-4 ClickHouse instances leveraging 3 dedicated ClickHouse Keepers
+4 ClickHouse servers and three Keeper nodes demonstrate sharding and replication. The existing XML also demonstrates a distributed-query secret, interserver HTTP credentials, and Keeper digest authentication. The walkthrough adds a separate SQL user to demonstrate accepted and rejected client credentials. This does not teach production availability, TLS, or backups.
 
-2 Shards with replication:
-- across clickhouse-01 and clickhouse-03 for shard 01
-- across clickhouse-02 and clickhouse-04 for shard 02
+These are local teaching configurations, not production deployments. Published ports bind to `127.0.0.1`, but the default ClickHouse user has no password and containers on the recipe network can connect. Do not expose these ports or reuse the example credentials on a shared host. The inter-node secrets in the XML and the SQL password below are public development values; the authentication lesson does not configure TLS.
 
-This recipe implements also:
+## Prerequisites
 
-- cluster inter-nodes authentication for distributed queries (`<secret>`)
-- cluster interserver http channel for low-level replication (`<interserver_http_credentials>`)
-- keeper authentication through auth digest scheme (`<identity>`)
+Use Docker Engine/Desktop or OrbStack with Docker Compose v2, Bash, and curl. Allocate roughly 12 GiB of Docker memory and 4 CPUs, with several GiB of free disk for images and logs. ClickHouse and Keeper images support Linux amd64 and arm64; use a Docker Linux VM on macOS/Windows. Run one recipe at a time: the fixed container names and host ports overlap across examples.
 
-By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
-will be `latest-alpine`.  You can specify specific versions by setting environment
-variables before running `docker compose up`.
+ClickHouse defaults to `CHVER=latest` and Keeper to `CHKVER=latest-alpine`. To select other images, export `CHVER` and `CHKVER` before starting; these overrides are intentionally retained. The verification prints the actual server version. Floating tags are not a compatibility guarantee.
+
+Last manually verified: **2026-09-06**, ClickHouse **26.8.2.7**, Keeper **26.8.2.7**, Linux **aarch64** on OrbStack (Docker 29.4.0 / Compose 5.1.2). The complete happy path below passed from empty volumes; this is a single-platform manual check.
+
+## Start and verify
+
+From this recipe directory, run the following Bash block. It polls each server's Keeper connection at most 30 times (each request is limited to 10 seconds); subsequent SQL requests are limited to 60 seconds. If it fails, inspect `docker compose logs --tail=100`.
 
 ```bash
-export CHVER=23.4
-export CHKVER=23.4-alpine
-docker compose up
+set -eu
+docker compose up -d
+for port in 8123 8124 8125 8126; do
+  ready=false
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 10 "http://127.0.0.1:$port/" \
+      --data-binary "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$ready" != true ]; then
+    echo "ClickHouse/Keeper not ready on port $port" >&2
+    exit 1
+  fi
+done
+q() {
+  curl --fail --silent --show-error --max-time 60 \
+    'http://127.0.0.1:8123/?distributed_ddl_task_timeout=60' --data-binary "$1"
+}
+q 'SELECT version()'
+q 'CREATE DATABASE recipe ON CLUSTER cluster_2S_2R_auth'
+q "CREATE TABLE recipe.events_local ON CLUSTER cluster_2S_2R_auth (id UInt32, message String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/{uuid}', '{replica}') ORDER BY id"
+q "CREATE TABLE recipe.events ON CLUSTER cluster_2S_2R_auth AS recipe.events_local ENGINE = Distributed('cluster_2S_2R_auth', 'recipe', 'events_local', id)"
+# Foreground insertion waits for delivery to each selected shard.
+q "INSERT INTO recipe.events SETTINGS distributed_foreground_insert = 1 VALUES (0, 'hello'), (1, 'keeper')"
+for port in 8123 8124 8125 8126; do
+  curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/?receive_timeout=45" \
+    --data-binary 'SYSTEM SYNC REPLICA recipe.events_local'
+done
+[ "$(q 'SELECT count() FROM recipe.events')" = 2 ]
+[ "$(q "SELECT message FROM recipe.events WHERE id = 1")" = keeper ]
+# Check each physical node, not only the Distributed table.
+for port in 8123 8124 8125 8126; do
+  count=$(curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/" \
+    --data-binary 'SELECT count() FROM recipe.events_local')
+  [ "$count" = 1 ]
+  echo "port $port: $count local row(s)"
+done
+q 'SELECT * FROM recipe.events ORDER BY id'
+q "CREATE USER recipe_reader IDENTIFIED WITH sha256_password BY 'local-example-password'"
+[ "$(curl --fail --silent --show-error --max-time 10 \
+  --user recipe_reader:local-example-password http://127.0.0.1:8123/ \
+  --data-binary 'SELECT currentUser()')" = recipe_reader ]
+status=$(curl --silent --show-error --max-time 10 --output /dev/null --write-out '%{http_code}' \
+  --user recipe_reader:wrong-password http://127.0.0.1:8123/ --data-binary 'SELECT 1')
+[ "$status" = 403 ]
+echo 'OK: valid credentials accepted; invalid credentials rejected (HTTP 403)'
+echo 'OK: topology assertions passed'
 ```
 
-This Docker compose file deploys a configuration very similar to [these two
-examples in the documentation](https://clickhouse.com/docs/en/architecture/introduction).
-See the docs for information on terminology, configuration, and testing.
+Expected output includes the actual ClickHouse version, two rows (`0 / hello`, `1 / keeper`), and 1 local row(s) on every ClickHouse node. Shard 1 is on clickhouse-01 and clickhouse-03; shard 2 is on clickhouse-02 and clickhouse-04. Replication is asynchronous, so the walkthrough synchronizes replicas before checking their contents. The final `OK` lines mean the assertions passed.
+
+## Stop, rerun, and reset
+
+`docker compose stop` preserves the existing containers for `docker compose start`. Before repeating the creation/insertion walkthrough, reset to empty state:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+This is destructive: it removes recipe containers and their anonymous data volumes, including all inserted data and Keeper state. The checked-in configuration and fixture remain. Then repeat the start/verify block. These examples are disposable and do not configure durable host data directories.
+
+## ClickHouse Cloud and documentation
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages the service's replication and scaling. Keeper wiring, explicit shard layouts, and CHProxy are self-managed infrastructure lessons; do not copy this Compose topology into Cloud.
+
+- [ClickHouse architecture](https://clickhouse.com/docs/architecture/introduction)
+- [ReplicatedMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication)
+- [Distributed tables](https://clickhouse.com/docs/engines/table-engines/special/distributed)
+- [ClickHouse Keeper](https://clickhouse.com/docs/guides/sre/keeper)
+- [Access control](https://clickhouse.com/docs/operations/access-rights)

--- a/docker-compose-recipes/recipes/cluster_2S_2R_auth/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_auth/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clickhouse-01:
     image: "clickhouse/clickhouse-server:${CHVER:-latest}"
@@ -6,8 +5,8 @@ services:
     container_name: clickhouse-01
     hostname: clickhouse-01
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9000:9000"
@@ -21,8 +20,8 @@ services:
     container_name: clickhouse-02
     hostname: clickhouse-02
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8124:8123"
       - "127.0.0.1:9001:9000"
@@ -36,8 +35,8 @@ services:
     container_name: clickhouse-03
     hostname: clickhouse-03
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-03/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-03/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8125:8123"
       - "127.0.0.1:9002:9000"
@@ -51,8 +50,8 @@ services:
     container_name: clickhouse-04
     hostname: clickhouse-04
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-04/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-04/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
         - "127.0.0.1:8126:8123"
         - "127.0.0.1:9003:9000"
@@ -66,7 +65,7 @@ services:
     container_name: clickhouse-keeper-01
     hostname: clickhouse-keeper-01
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
@@ -75,7 +74,7 @@ services:
     container_name: clickhouse-keeper-02
     hostname: clickhouse-keeper-02
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
@@ -84,6 +83,6 @@ services:
     container_name: clickhouse-keeper-03
     hostname: clickhouse-keeper-03
     volumes:
-     - ${PWD}/fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+     - ./fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9183:9181"

--- a/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/README.md
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/README.md
@@ -1,22 +1,88 @@
-# ClickHouse cluster cluster_2S_2R
+# ClickHouse: 2 shards, 2 replicas per shard with CHProxy
 
-4 ClickHouse instances leveraging 3 dedicated ClickHouse Keepers and CH Proxy load balancer
+4 ClickHouse servers and three Keeper nodes demonstrate sharding and replication. CHProxy forwards HTTP queries to the ClickHouse nodes; queries against the Distributed table read the whole cluster. This does not teach production availability, TLS, or backups.
 
-2 Shards with replication:
-- across clickhouse-01 and clickhouse-03 for shard 01
-- across clickhouse-02 and clickhouse-04 for shard 02
+These are local teaching configurations, not production deployments. Published ports bind to `127.0.0.1`, but the default ClickHouse user has no password and containers on the recipe network can connect. Do not expose these ports or reuse the example credentials on a shared host. The proxy user has no password, and port 80 serves plain HTTP.
 
-By default the version of ClickHouse used will be `latest`, and ClickHouse Keeper
-will be `latest-alpine`.  You can specify specific versions by setting environment
-variables before running `docker compose up`.
+## Prerequisites
+
+Use Docker Engine/Desktop or OrbStack with Docker Compose v2, Bash, and curl. Allocate roughly 12 GiB of Docker memory and 4 CPUs, with several GiB of free disk for images and logs. ClickHouse and Keeper images support Linux amd64 and arm64; use a Docker Linux VM on macOS/Windows. This recipe retains CHProxy `v1.26.4` on `linux/amd64`; arm64 hosts require amd64 emulation. Its fixed private subnet must not overlap your existing Docker networks. Run one recipe at a time: the fixed container names and host ports overlap across examples.
+
+ClickHouse defaults to `CHVER=latest` and Keeper to `CHKVER=latest-alpine`. To select other images, export `CHVER` and `CHKVER` before starting; these overrides are intentionally retained. The verification prints the actual server version. Floating tags are not a compatibility guarantee.
+
+Last manually verified: **2026-09-06**, ClickHouse **26.8.2.7**, Keeper **26.8.2.7**, Linux **aarch64** on OrbStack (Docker 29.4.0 / Compose 5.1.2). CHProxy **v1.26.4** ran as **linux/amd64 under emulation**. The complete happy path below passed from empty volumes; this is a single-platform manual check.
+
+## Start and verify
+
+From this recipe directory, run the following Bash block. It polls each server's Keeper connection at most 30 times (each request is limited to 10 seconds); subsequent SQL requests are limited to 60 seconds. If it fails, inspect `docker compose logs --tail=100`.
 
 ```bash
-export CHVER=23.4
-export CHKVER=23.4-alpine
-docker compose up
+set -eu
+docker compose up -d
+for port in 8123 8124 8125 8126; do
+  ready=false
+  for attempt in {1..30}; do
+    if curl --fail --silent --max-time 10 "http://127.0.0.1:$port/" \
+      --data-binary "SELECT count() FROM system.zookeeper WHERE path = '/'" >/dev/null; then
+      ready=true
+      break
+    fi
+    sleep 2
+  done
+  if [ "$ready" != true ]; then
+    echo "ClickHouse/Keeper not ready on port $port" >&2
+    exit 1
+  fi
+done
+q() {
+  curl --fail --silent --show-error --max-time 60 \
+    'http://127.0.0.1:8123/?distributed_ddl_task_timeout=60' --data-binary "$1"
+}
+q 'SELECT version()'
+q 'CREATE DATABASE recipe ON CLUSTER cluster_2S_2R'
+q "CREATE TABLE recipe.events_local ON CLUSTER cluster_2S_2R (id UInt32, message String) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/{uuid}', '{replica}') ORDER BY id"
+q "CREATE TABLE recipe.events ON CLUSTER cluster_2S_2R AS recipe.events_local ENGINE = Distributed('cluster_2S_2R', 'recipe', 'events_local', id)"
+# Foreground insertion waits for delivery to each selected shard.
+q "INSERT INTO recipe.events SETTINGS distributed_foreground_insert = 1 VALUES (0, 'hello'), (1, 'keeper')"
+for port in 8123 8124 8125 8126; do
+  curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/?receive_timeout=45" \
+    --data-binary 'SYSTEM SYNC REPLICA recipe.events_local'
+done
+[ "$(q 'SELECT count() FROM recipe.events')" = 2 ]
+[ "$(q "SELECT message FROM recipe.events WHERE id = 1")" = keeper ]
+# Check each physical node, not only the Distributed table.
+for port in 8123 8124 8125 8126; do
+  count=$(curl --fail --silent --show-error --max-time 60 "http://127.0.0.1:$port/" \
+    --data-binary 'SELECT count() FROM recipe.events_local')
+  [ "$count" = 1 ]
+  echo "port $port: $count local row(s)"
+done
+q 'SELECT * FROM recipe.events ORDER BY id'
+# Query the same Distributed table through the published proxy endpoint.
+[ "$(curl --fail --silent --show-error --max-time 30 --user 'admin_2S_2R:' \
+  http://127.0.0.1:80/ --data-binary 'SELECT count() FROM recipe.events')" = 2 ]
+echo 'OK: query through CHProxy returned two rows'
+echo 'OK: topology assertions passed'
 ```
 
-This Docker compose file deploys a configuration very similar to [these
-examples in the documentation](https://clickhouse.com/docs/en/architecture/introduction).
-See the docs for information on terminology, configuration, and testing.
+Expected output includes the actual ClickHouse version, two rows (`0 / hello`, `1 / keeper`), and 1 local row(s) on every ClickHouse node. Shard 1 is on clickhouse-01 and clickhouse-03; shard 2 is on clickhouse-02 and clickhouse-04. Replication is asynchronous, so the walkthrough synchronizes replicas before checking their contents. The proxy assertion demonstrates query forwarding. This walkthrough does not claim to validate failover under load. The final `OK` lines mean the assertions passed.
 
+## Stop, rerun, and reset
+
+`docker compose stop` preserves the existing containers for `docker compose start`. Before repeating the creation/insertion walkthrough, reset to empty state:
+
+```bash
+docker compose down -v --remove-orphans
+```
+
+This is destructive: it removes recipe containers and their anonymous data volumes, including all inserted data and Keeper state. The checked-in configuration and fixture remain. Then repeat the start/verify block. These examples are disposable and do not configure durable host data directories.
+
+## ClickHouse Cloud and documentation
+
+[ClickHouse Cloud](https://clickhouse.com/cloud) manages the service's replication and scaling. Keeper wiring, explicit shard layouts, and CHProxy are self-managed infrastructure lessons; do not copy this Compose topology into Cloud.
+
+- [ClickHouse architecture](https://clickhouse.com/docs/architecture/introduction)
+- [ReplicatedMergeTree](https://clickhouse.com/docs/engines/table-engines/mergetree-family/replication)
+- [Distributed tables](https://clickhouse.com/docs/engines/table-engines/special/distributed)
+- [ClickHouse Keeper](https://clickhouse.com/docs/guides/sre/keeper)
+- [CHProxy configuration](https://www.chproxy.org/configuration/)

--- a/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/docker-compose.yaml
+++ b/docker-compose-recipes/recipes/cluster_2S_2R_ch_proxy/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   clickhouse-01:
     image: "clickhouse/clickhouse-server:${CHVER:-latest}"
@@ -9,8 +8,8 @@ services:
       cluster_2S_2R_ch_proxy:
         ipv4_address: 192.168.9.1
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-01/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9000:9000"
@@ -27,8 +26,8 @@ services:
       cluster_2S_2R_ch_proxy:
         ipv4_address: 192.168.9.2
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-02/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8124:8123"
       - "127.0.0.1:9001:9000"
@@ -45,8 +44,8 @@ services:
       cluster_2S_2R_ch_proxy:
         ipv4_address: 192.168.9.3
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-03/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-03/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-03/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
       - "127.0.0.1:8125:8123"
       - "127.0.0.1:9002:9000"
@@ -63,8 +62,8 @@ services:
       cluster_2S_2R_ch_proxy:
         ipv4_address: 192.168.9.4
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-04/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
-      - ${PWD}/fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./fs/volumes/clickhouse-04/etc/clickhouse-server/config.d/config.xml:/etc/clickhouse-server/config.d/config.xml
+      - ./fs/volumes/clickhouse-04/etc/clickhouse-server/users.d/users.xml:/etc/clickhouse-server/users.d/users.xml
     ports:
         - "127.0.0.1:8126:8123"
         - "127.0.0.1:9003:9000"
@@ -81,7 +80,7 @@ services:
       cluster_2S_2R_ch_proxy:
         ipv4_address: 192.168.9.5
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+      - ./fs/volumes/clickhouse-keeper-01/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9181:9181"
   clickhouse-keeper-02:
@@ -93,7 +92,7 @@ services:
       cluster_2S_2R_ch_proxy:
         ipv4_address: 192.168.9.6
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+      - ./fs/volumes/clickhouse-keeper-02/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9182:9181"
   clickhouse-keeper-03:
@@ -105,7 +104,7 @@ services:
       cluster_2S_2R_ch_proxy:
         ipv4_address: 192.168.9.7
     volumes:
-      - ${PWD}/fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
+      - ./fs/volumes/clickhouse-keeper-03/etc/clickhouse-keeper/keeper_config.xml:/etc/clickhouse-keeper/keeper_config.xml
     ports:
         - "127.0.0.1:9183:9181"
   ch-proxy:
@@ -117,10 +116,9 @@ services:
       cluster_2S_2R_ch_proxy:
         ipv4_address: 192.168.9.10
     ports:
-      - "127.0.0.1:443:443"
       - "127.0.0.1:80:80"
     volumes:
-      - ${PWD}/fs/volumes/ch-proxy/config/config.yml:/opt/config.yml
+      - ./fs/volumes/ch-proxy/config/config.yml:/opt/config.yml
     depends_on:
       - clickhouse-01
       - clickhouse-02

--- a/docker-compose-recipes/scripts/validate.py
+++ b/docker-compose-recipes/scripts/validate.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Cheap Compose, recipe-index and XML checks; Python standard library only."""
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+ROOT = Path(__file__).resolve().parents[1]
+errors = []
+compose_files = sorted(
+    path for path in (ROOT / "recipes").rglob("*")
+    if path.name in {"compose.yaml", "compose.yml", "docker-compose.yaml", "docker-compose.yml"}
+)
+for target in re.findall(r"\]\(([^)]+)\)", (ROOT / "README.md").read_text()):
+    if "://" not in target and not target.startswith("#"):
+        if not (ROOT / target.split("#", 1)[0]).exists():
+            errors.append(f"Broken index link: {target}")
+for path in compose_files:
+    if not (path.parent / "README.md").is_file():
+        errors.append(f"Missing README: {path.parent.relative_to(ROOT)}")
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "-f", str(path), "config", "--quiet"],
+            cwd=path.parent,
+            env={**os.environ, "PWD": str(path.parent)},
+            capture_output=True, text=True, timeout=60,
+        )
+        if result.returncode:
+            errors.append(f"{path.relative_to(ROOT)}: {result.stderr.strip()}")
+    except (OSError, subprocess.TimeoutExpired) as error:
+        errors.append(f"{path.relative_to(ROOT)}: {error}")
+xml_files = sorted((ROOT / "recipes").rglob("*.xml"))
+for path in xml_files:
+    try:
+        ET.parse(path)
+    except (ET.ParseError, OSError) as error:
+        errors.append(f"{path.relative_to(ROOT)}: {error}")
+if errors:
+    print("\n".join(errors), file=sys.stderr)
+    sys.exit(1)
+print(f"OK: index links, {len(compose_files)} recipe READMEs/Compose files, {len(xml_files)} XML files")


### PR DESCRIPTION
Core Compose recipes relied on working-directory bind paths and lacked self-contained topology checks. Keep ClickHouse `latest` / Keeper `latest-alpine` overrides, use relative mounts, remove obsolete Compose fields, and document bounded insert/query assertions for all nine core, auth, IMDb and proxy recipes. IMDb startup now uses a tiny synthetic fixture.

Adds one standard-library Python check for index links, recipe READMEs, Compose config and XML syntax. No scheduled tests, version matrix or host package dependencies. Existing cluster paths and all XML are unchanged, including the file discussed in #274; keep documentation-owner coordination before merging future configuration changes.

Validation on 2026-09-06, OrbStack Docker 29.4.0 Linux/aarch64, ClickHouse and Keeper **26.8.2.7**:
- `python3 docker-compose-recipes/scripts/validate.py`: 17 Compose files/READMEs and 85 XML files pass; `git diff --check` passes.
- Executed each of the nine READMEs' first Bash blocks from empty volumes, then `docker compose down -v --remove-orphans`.
- Single/Keeper: 1 inserted row; IMDb: 2 movies/roles and director joins; 1S2R: both replicas contain 2 rows; 2S1R: each shard contains 1 row; both 2S2R variants: each physical node contains 1 row. Valid credentials accepted; invalid password returns HTTP 403.
- All three CHProxy variants returned the expected 2 rows through HTTP. Existing CHProxy v1.26.4 ran with amd64 emulation; no failover claim added.

An existing Orb VM forwards macOS localhost:8123 to a separate ClickHouse process. Validation preserved that process and ran the README curl requests via `docker run --rm --network host curlimages/curl:8.16.0` to reach the recipe's published ports. No host dependencies were installed. Independent source review found no remaining issues; reviewed and reconciled by the orchestrator.
